### PR TITLE
[Backend] Add GET /health endpoint

### DIFF
--- a/src/SmartEstate.API/Controllers/HealthController.cs
+++ b/src/SmartEstate.API/Controllers/HealthController.cs
@@ -1,0 +1,23 @@
+using System.Reflection;
+using Microsoft.AspNetCore.Mvc;
+using SmartEstate.Application.Common.Models;
+
+namespace SmartEstate.API.Controllers;
+
+[ApiController]
+[Route("[controller]")]
+public class HealthController : ControllerBase
+{
+    [HttpGet]
+    public IActionResult Get()
+    {
+        var data = new
+        {
+            AppName = "SmartEstate API",
+            Version = Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "1.0.0",
+            Timestamp = DateTime.UtcNow
+        };
+
+        return Ok(ApiResponse<object>.Ok(data, "Healthy"));
+    }
+}

--- a/test-hello.txt
+++ b/test-hello.txt
@@ -1,0 +1,1 @@
+Hello World


### PR DESCRIPTION
## Summary
- Added `GET /health` endpoint in `HealthController` returning 200 OK with app name, version, and UTC timestamp
- Response wrapped in `ApiResponse<T>` per project convention
- Endpoint is anonymous (no auth required — health checks must be publicly accessible)
- No MediatR used: this is infrastructure metadata, not business logic

## Test plan
- [ ] `GET https://localhost:7001/health` returns 200 OK
- [ ] Response body contains `appName`, `version`, and `timestamp` fields under `data`

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)