### PR TITLE
[Backend] Add GET /ping endpoint

### DIFF
--- a/src/SmartEstate.API/Controllers/PingController.cs
+++ b/src/SmartEstate.API/Controllers/PingController.cs
@@ -1,0 +1,15 @@
+using Microsoft.AspNetCore.Mvc;
+using SmartEstate.Application.Common.Models;
+
+namespace SmartEstate.API.Controllers;
+
+[ApiController]
+[Route("[controller]")]
+public class PingController : ControllerBase
+{
+    [HttpGet]
+    public IActionResult Get()
+    {
+        return Ok(ApiResponse<string>.Ok("pong"));
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `GET /ping` endpoint to `PingController` that returns `"pong"` wrapped in `ApiResponse<string>`
- Follows the same pattern as the existing `HealthController`

## What was implemented
- `src/SmartEstate.API/Controllers/PingController.cs` — new controller with a single `[HttpGet]` action returning `ApiResponse<string>.Ok("pong")`

## Deviations
None.

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)