### PR TITLE
[Backend] Add tenant info endpoint

### DIFF
--- a/src/SmartEstate.API/Controllers/TenantController.cs
+++ b/src/SmartEstate.API/Controllers/TenantController.cs
@@ -1,0 +1,31 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using SmartEstate.Application.Common.Interfaces;
+using SmartEstate.Application.Common.Models;
+
+namespace SmartEstate.API.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+[Authorize]
+public class TenantController(ITenantContext tenantContext, IApplicationDbContext db) : ControllerBase
+{
+    [HttpGet("info")]
+    public async Task<IActionResult> GetInfo(CancellationToken ct)
+    {
+        if (tenantContext.TenantId is null)
+            return Forbid();
+
+        var tenant = await db.Tenants
+            .AsNoTracking()
+            .Where(t => t.Id == tenantContext.TenantId.Value)
+            .Select(t => new { t.Id, t.Name })
+            .FirstOrDefaultAsync(ct);
+
+        if (tenant is null)
+            return NotFound(ApiResponse.Fail("Tenant not found."));
+
+        return Ok(ApiResponse<object>.Ok(tenant));
+    }
+}

--- a/src/SmartEstate.Application/Common/Constants/AppClaims.cs
+++ b/src/SmartEstate.Application/Common/Constants/AppClaims.cs
@@ -1,0 +1,6 @@
+namespace SmartEstate.Application.Common.Constants;
+
+public static class AppClaims
+{
+    public const string TenantId = "tenant_id";
+}

--- a/src/SmartEstate.Infrastructure/DependencyInjection.cs
+++ b/src/SmartEstate.Infrastructure/DependencyInjection.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
@@ -5,6 +6,7 @@ using Microsoft.Extensions.DependencyInjection;
 using SmartEstate.Application.Common.Interfaces;
 using SmartEstate.Infrastructure.Identity;
 using SmartEstate.Infrastructure.Persistence;
+using SmartEstate.Infrastructure.Services;
 
 namespace SmartEstate.Infrastructure;
 
@@ -12,6 +14,8 @@ public static class DependencyInjection
 {
     public static IServiceCollection AddInfrastructure(this IServiceCollection services, IConfiguration configuration)
     {
+        services.AddScoped<ITenantContext, TenantContext>();
+
         services.AddDbContext<AppDbContext>((sp, options) =>
         {
             options.UseNpgsql(configuration.GetConnectionString("DefaultConnection"),

--- a/src/SmartEstate.Infrastructure/Services/TenantContext.cs
+++ b/src/SmartEstate.Infrastructure/Services/TenantContext.cs
@@ -1,5 +1,7 @@
 using Microsoft.AspNetCore.Http;
+using SmartEstate.Application.Common.Constants;
 using SmartEstate.Application.Common.Interfaces;
+using SmartEstate.Infrastructure.Identity;
 
 namespace SmartEstate.Infrastructure.Services;
 
@@ -9,11 +11,11 @@ public class TenantContext(IHttpContextAccessor httpContextAccessor) : ITenantCo
     {
         get
         {
-            var claim = httpContextAccessor.HttpContext?.User.FindFirst("tenant_id");
+            var claim = httpContextAccessor.HttpContext?.User.FindFirst(AppClaims.TenantId);
             return claim is not null && Guid.TryParse(claim.Value, out var id) ? id : null;
         }
     }
 
     public bool IsAdministrator =>
-        httpContextAccessor.HttpContext?.User.IsInRole("Administrator") ?? false;
+        httpContextAccessor.HttpContext?.User.IsInRole(AppRoles.Administrator) ?? false;
 }

--- a/src/SmartEstate.Infrastructure/Services/TenantContext.cs
+++ b/src/SmartEstate.Infrastructure/Services/TenantContext.cs
@@ -1,0 +1,19 @@
+using Microsoft.AspNetCore.Http;
+using SmartEstate.Application.Common.Interfaces;
+
+namespace SmartEstate.Infrastructure.Services;
+
+public class TenantContext(IHttpContextAccessor httpContextAccessor) : ITenantContext
+{
+    public Guid? TenantId
+    {
+        get
+        {
+            var claim = httpContextAccessor.HttpContext?.User.FindFirst("tenant_id");
+            return claim is not null && Guid.TryParse(claim.Value, out var id) ? id : null;
+        }
+    }
+
+    public bool IsAdministrator =>
+        httpContextAccessor.HttpContext?.User.IsInRole("Administrator") ?? false;
+}

--- a/src/SmartEstate.Infrastructure/SmartEstate.Infrastructure.csproj
+++ b/src/SmartEstate.Infrastructure/SmartEstate.Infrastructure.csproj
@@ -22,4 +22,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## What was implemented

- `GET /api/tenant/info` — returns the authenticated user's tenant `Id` and `Name`
- `TenantContext` service (`Infrastructure/Services/TenantContext.cs`) — reads the `tenant_id` JWT claim via `IHttpContextAccessor` and implements `ITenantContext`
- Registered `ITenantContext → TenantContext` as scoped in `Infrastructure/DependencyInjection.cs`
- Added `FrameworkReference` to `Microsoft.AspNetCore.App` in the Infrastructure csproj (needed to resolve `IHttpContextAccessor` in a class library)

## Deviations from issue spec

As instructed by the issue, the database query is placed directly in the controller — CQRS/MediatR is skipped for this endpoint.

## Migration instructions

No new migrations required.

## Follow-up issues

None.

Closes #8