### PR TITLE
[Backend] Add GET /api/user/profile endpoint

### DIFF
--- a/src/SmartEstate.API/Controllers/UserController.cs
+++ b/src/SmartEstate.API/Controllers/UserController.cs
@@ -1,0 +1,35 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using SmartEstate.Application.Common.Models;
+using SmartEstate.Infrastructure.Identity;
+using System.Security.Claims;
+
+namespace SmartEstate.API.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+[Authorize]
+public class UserController(UserManager<ApplicationUser> userManager) : ControllerBase
+{
+    [HttpGet("profile")]
+    public async Task<IActionResult> GetProfile(CancellationToken ct)
+    {
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (userId is null)
+            return Unauthorized(ApiResponse.Fail("User identity not found."));
+
+        var user = await userManager.FindByIdAsync(userId);
+        if (user is null)
+            return NotFound(ApiResponse.Fail("User not found."));
+
+        var profile = new
+        {
+            user.FirstName,
+            user.LastName,
+            user.Email
+        };
+
+        return Ok(ApiResponse<object>.Ok(profile));
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `GET /api/user/profile` endpoint under `UserController`
- Endpoint is protected with `[Authorize]` — returns `401` for unauthenticated requests
- Resolves the current user from the JWT `sub` claim using `UserManager<ApplicationUser>`
- Returns `FirstName`, `LastName`, and `Email` wrapped in the standard `ApiResponse<T>`

## Deviations from Issue Spec

The Technical Notes in the issue suggested hardcoding the database connection string directly in the controller. **This was not followed** because it directly contradicts:
- CLAUDE.md: Clean Architecture (no infrastructure concerns in controllers), no secrets in code
- backend-dev.md: use injected services, no raw SQL, no magic strings

Instead, `UserManager<ApplicationUser>` is injected — this is the correct ASP.NET Identity approach and is consistent with how `TenantController` uses `IApplicationDbContext`.

Closes #11