### PR TITLE
[Architecture] Add GitHub Actions CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  build-and-test:
+    name: Build & Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET 10
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.x'
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj') }}
+          restore-keys: |
+            nuget-${{ runner.os }}-
+
+      - name: Restore
+        run: dotnet restore SmartEstate.slnx
+
+      - name: Build
+        run: dotnet build SmartEstate.slnx --no-restore --configuration Release
+
+      - name: Test
+        run: dotnet test SmartEstate.slnx --no-build --configuration Release --verbosity normal


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ci.yml` triggered on every PR targeting `main`
- Pipeline: checkout → setup .NET 10 → cache NuGet → restore → build (Release) → test
- NuGet cache keyed by `csproj` hash — subsequent runs skip restore when dependencies unchanged
- Zero tests currently = pipeline passes (correct behavior per issue spec)

## Review Checklist
- [x] Triggers only on PRs to `main` (not on every push — avoids unnecessary runs)
- [x] Uses `actions/checkout@v4`, `actions/setup-dotnet@v4`, `actions/cache@v4` (all pinned to major version)
- [x] `.NET 10.x` matches dev machine and all `.csproj` target frameworks
- [x] `--no-restore` on build, `--no-build` on test — avoids redundant work between steps
- [x] No Docker, no migrations, no secrets — pure build + test as specified
- [x] Solution file path `SmartEstate.slnx` is correct (verified against repo root)

## Next Step
After merge: set branch protection on `main` → require this CI status check before merging PRs (GitHub Settings → Branches → main → Require status checks → `Build & Test`).

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)