### PR TITLE
[Backend] Configure Serilog structured logging for API and Workers

### DIFF
--- a/src/SmartEstate.API/Program.cs
+++ b/src/SmartEstate.API/Program.cs
@@ -4,13 +4,20 @@ using Microsoft.IdentityModel.Tokens;
 using Serilog;
 using SmartEstate.Application;
 using SmartEstate.Infrastructure;
+using SmartEstate.Infrastructure.Logging;
 
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Host.UseSerilog((ctx, cfg) =>
     cfg.ReadFrom.Configuration(ctx.Configuration)
        .Enrich.FromLogContext()
-       .WriteTo.Console());
+       .Destructure.With<SensitivePropertyDestructuringPolicy>()
+       .WriteTo.Console()
+       .WriteTo.File(
+           "logs/smartestate-.log",
+           rollingInterval: RollingInterval.Day,
+           retainedFileCountLimit: 7,
+           outputTemplate: "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level:u3}] {Message:lj}{NewLine}{Exception}"));
 
 builder.Services.AddApplication();
 builder.Services.AddInfrastructure(builder.Configuration);

--- a/src/SmartEstate.API/SmartEstate.API.csproj
+++ b/src/SmartEstate.API/SmartEstate.API.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.5" />
     <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
+    <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SmartEstate.Infrastructure/Logging/SensitivePropertyDestructuringPolicy.cs
+++ b/src/SmartEstate.Infrastructure/Logging/SensitivePropertyDestructuringPolicy.cs
@@ -1,0 +1,38 @@
+using System.Reflection;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace SmartEstate.Infrastructure.Logging;
+
+public sealed class SensitivePropertyDestructuringPolicy : IDestructuringPolicy
+{
+    private static readonly HashSet<string> _sensitiveNames = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "password", "passwordhash", "token", "accesstoken", "refreshtoken",
+        "secret", "apikey", "api_key", "authorization", "credential", "credentials"
+    };
+
+    public bool TryDestructure(object value, ILogEventPropertyValueFactory propertyValueFactory, out LogEventPropertyValue result)
+    {
+        var type = value.GetType();
+
+        if (type.Namespace?.StartsWith("SmartEstate") != true)
+        {
+            result = null!;
+            return false;
+        }
+
+        var properties = type
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(p => p.CanRead && p.GetIndexParameters().Length == 0)
+            .Select(p => new LogEventProperty(
+                p.Name,
+                _sensitiveNames.Contains(p.Name)
+                    ? new ScalarValue("***REDACTED***")
+                    : propertyValueFactory.CreatePropertyValue(p.GetValue(value), true)))
+            .ToList();
+
+        result = new StructureValue(properties);
+        return true;
+    }
+}

--- a/src/SmartEstate.Workers/Program.cs
+++ b/src/SmartEstate.Workers/Program.cs
@@ -1,6 +1,20 @@
+using Serilog;
+using SmartEstate.Infrastructure.Logging;
 using SmartEstate.Workers;
 
 var builder = Host.CreateApplicationBuilder(args);
+
+builder.Services.AddSerilog((_, cfg) =>
+    cfg.ReadFrom.Configuration(builder.Configuration)
+       .Enrich.FromLogContext()
+       .Destructure.With<SensitivePropertyDestructuringPolicy>()
+       .WriteTo.Console()
+       .WriteTo.File(
+           "logs/smartestate-workers-.log",
+           rollingInterval: RollingInterval.Day,
+           retainedFileCountLimit: 7,
+           outputTemplate: "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level:u3}] {Message:lj}{NewLine}{Exception}"));
+
 builder.Services.AddHostedService<Worker>();
 
 var host = builder.Build();

--- a/src/SmartEstate.Workers/SmartEstate.Workers.csproj
+++ b/src/SmartEstate.Workers/SmartEstate.Workers.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
+    <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SmartEstate.Workers/appsettings.json
+++ b/src/SmartEstate.Workers/appsettings.json
@@ -4,5 +4,15 @@
       "Default": "Information",
       "Microsoft.Hosting.Lifetime": "Information"
     }
+  },
+  "Serilog": {
+    "MinimumLevel": {
+      "Default": "Information",
+      "Override": {
+        "Microsoft": "Warning",
+        "System": "Warning",
+        "Microsoft.Hosting.Lifetime": "Information"
+      }
+    }
   }
 }


### PR DESCRIPTION
## Closes #15

## What was implemented

- **Rolling file sink** added to both `SmartEstate.API` and `SmartEstate.Workers` — writes to `logs/smartestate-.log` and `logs/smartestate-workers-.log` respectively (daily roll, 7-day retention)
- **Serilog configured in Workers** — previously the Workers project had no structured logging; now uses `AddSerilog()` with the same configuration pattern as the API
- **`SensitivePropertyDestructuringPolicy`** added in `SmartEstate.Infrastructure/Logging/` — redacts properties named `password`, `passwordhash`, `token`, `accesstoken`, `refreshtoken`, `secret`, `apikey`, `authorization`, `credential(s)` when SmartEstate types are destructured via `{@obj}` syntax
- **`Serilog:MinimumLevel`** section added to `Workers/appsettings.json` for consistent log level configuration
- `Serilog.Sinks.File 7.0.0` used (required by `Serilog.AspNetCore 10.0.0` transitive dependency)

## Deviations from issue spec

None. `logs/` was already in `.gitignore` from a prior commit.

## Follow-up issues

None.