### PR TITLE
[Backend] Complete Docker Compose setup for local development

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# Copy this file to .env and fill in values before running docker-compose up
+# .env is gitignored and must never be committed
+
+# PostgreSQL — matches ConnectionStrings:DefaultConnection in appsettings.json
+POSTGRES_PASSWORD=your_postgres_password_here
+
+# pgAdmin web UI (http://localhost:5050)
+PGADMIN_DEFAULT_EMAIL=admin@smartestate.local
+PGADMIN_DEFAULT_PASSWORD=your_pgadmin_password_here
+
+# n8n workflow automation (http://localhost:5678)
+N8N_BASIC_AUTH_USER=admin
+N8N_BASIC_AUTH_PASSWORD=your_n8n_password_here

--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ coverage/
 *.p12
 secrets.json
 local.settings.json
+.env
 
 # OS
 .DS_Store

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 services:
   postgres:
     image: postgres:16-alpine
@@ -8,7 +6,7 @@ services:
     environment:
       POSTGRES_DB: smartestate
       POSTGRES_USER: smartestate
-      POSTGRES_PASSWORD: SmartEstate_Dev_2024!
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
     ports:
       - "5432:5432"
     volumes:
@@ -24,8 +22,8 @@ services:
     container_name: smartestate-pgadmin
     restart: unless-stopped
     environment:
-      PGADMIN_DEFAULT_EMAIL: admin@smartestate.com
-      PGADMIN_DEFAULT_PASSWORD: admin
+      PGADMIN_DEFAULT_EMAIL: ${PGADMIN_DEFAULT_EMAIL}
+      PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_DEFAULT_PASSWORD}
       PGADMIN_CONFIG_SERVER_MODE: 'False'
       PGADMIN_CONFIG_MASTER_PASSWORD_REQUIRED: 'False'
       PGADMIN_CONFIG_CHECK_EMAIL_DELIVERABILITY: 'False'
@@ -33,6 +31,7 @@ services:
       - "5050:80"
     volumes:
       - pgadmin_data:/var/lib/pgadmin
+      - ./docker/pgadmin/servers.json:/pgadmin4/servers.json:ro
     depends_on:
       postgres:
         condition: service_healthy
@@ -48,8 +47,8 @@ services:
       - WEBHOOK_URL=http://localhost:5678/
       - GENERIC_TIMEZONE=Europe/Belgrade
       - N8N_BASIC_AUTH_ACTIVE=true
-      - N8N_BASIC_AUTH_USER=admin
-      - N8N_BASIC_AUTH_PASSWORD=SmartEstate_n8n_2024!
+      - N8N_BASIC_AUTH_USER=${N8N_BASIC_AUTH_USER}
+      - N8N_BASIC_AUTH_PASSWORD=${N8N_BASIC_AUTH_PASSWORD}
     ports:
       - "5678:5678"
     volumes:

--- a/docker/pgadmin/servers.json
+++ b/docker/pgadmin/servers.json
@@ -1,0 +1,14 @@
+{
+  "Servers": {
+    "1": {
+      "Name": "SmartEstate Local",
+      "Group": "Servers",
+      "Host": "postgres",
+      "Port": 5432,
+      "MaintenanceDB": "smartestate",
+      "Username": "smartestate",
+      "SSLMode": "prefer",
+      "PassFile": "/tmp/pgpassfile"
+    }
+  }
+}


### PR DESCRIPTION
## Closes #13

## What was implemented

- **Credentials moved to `.env`** — PostgreSQL password, pgAdmin credentials, and n8n basic auth credentials are no longer hardcoded in `docker-compose.yml`; they are loaded from a `.env` file via `${VARIABLE}` syntax
- **`.env.example`** — Documents all required environment variables with instructions; copy to `.env` and fill in values before running
- **`.env` added to `.gitignore`** — Ensures the local `.env` file is never accidentally committed
- **`docker/pgadmin/servers.json`** — pgAdmin server configuration mounted as read-only volume; avoids manual server setup on every fresh container start (connects to the `postgres` service automatically)
- **Removed obsolete `version: '3.9'`** — Docker Compose no longer uses this field; removing it eliminates the deprecation warning

## How to start local environment

```bash
cp .env.example .env
# Edit .env and set your passwords
docker compose up -d
```

- PostgreSQL: `localhost:5432`
- pgAdmin: `http://localhost:5050`
- n8n: `http://localhost:5678`

## Deviations from issue spec

None.

## Follow-up issues

None.