### PR TITLE
[Backend] Implement TenantMiddleware — resolve ITenantContext from JWT tenant_id claim

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -217,7 +217,7 @@ Owner reviews milestone → plans next sprint with Lead Dev
 | Sprint | Status | Summary |
 |---|---|---|
 | Sprint 0 | ✅ Complete | Foundation — Docker, EF Core migration, Serilog, Blazor layout, CI pipeline |
-| Sprint 1 | Planned | Auth (JWT login), multi-tenancy middleware, admin tenant/user management |
+| Sprint 1 | 🔄 In Progress | Auth (JWT login), multi-tenancy middleware, admin tenant/user management |
 | Sprint 2 | Planned | Buyer CRUD (backend + frontend) |
 | Sprint 3 | Planned | Property CRUD (backend + frontend) |
 | Sprint 4 | Planned | Gemini AI tagging for buyers and properties |
@@ -261,7 +261,7 @@ Owner reviews milestone → plans next sprint with Lead Dev
 
 ---
 
-### Sprint 1 — Auth & Multi-Tenancy `[Planned — Next]`
+### Sprint 1 — Auth & Multi-Tenancy `[🔄 In Progress]`
 
 **Goal:** No one can do anything without auth. This sprint is a hard blocker for all feature sprints.
 **Depends on:** Sprint 0 complete ✅.
@@ -507,6 +507,12 @@ Owner reviews milestone → plans next sprint with Lead Dev
 - `Administrator` role is seeded on first run — credentials read from `ADMIN_EMAIL` / `ADMIN_PASSWORD` env vars (or `appsettings.Development.json`); if not set, seeder skips with a warning log
 - CORS policy in API is named `"BlazorWasm"` — configured for `https://localhost:7002` in dev; update `AllowedOrigins` in `appsettings.json` for prod
 - Scraping portals (4zida, halooglasi, etc.) may change their HTML structure — scrapers must fail gracefully, log full context, and continue; never crash the worker
+- `System.IdentityModel.Tokens.Jwt 8.17.0` must be explicitly added to Infrastructure — it is NOT transitively available via `FrameworkReference Include="Microsoft.AspNetCore.App"` even though JwtBearer is in the framework
+- `UseSerilogRequestLogging()` must come **before** `UseExceptionHandler()` in `Program.cs` — otherwise Serilog does not capture the rewritten status code from exception handling
+- `GlobalExceptionHandler` (implements `IExceptionHandler`) is in `API/Common/` — catches `FluentValidation.ValidationException` from the MediatR pipeline and returns `400 Bad Request` with `ApiResponse` shape; catches all other exceptions and returns `500`
+- `IAuthService` pattern: when Application handlers need Identity concerns (`UserManager` etc.), define `IXxxService` in Application and implement in Infrastructure — keeps Application layer free of Identity types
+- `JwtSettings` options class at `Infrastructure/Identity/JwtSettings.cs`, bound via `services.Configure<JwtSettings>(configuration.GetSection("Jwt"))` — properties: `Secret`, `Issuer`, `Audience`, `ExpiryMinutes` (default 60)
+- JWT `Secret` is validated at startup (≥ 32 chars) — app throws `InvalidOperationException` if missing or too short; placeholder in `appsettings.json` is long enough for dev
 
 ### Frontend
 - Docker Compose credentials are in `.env` (gitignored) — copy `.env.example` to `.env` before first `docker compose up -d`

--- a/src/SmartEstate.API/Program.cs
+++ b/src/SmartEstate.API/Program.cs
@@ -6,6 +6,7 @@ using SmartEstate.API.Common;
 using SmartEstate.Application;
 using SmartEstate.Infrastructure;
 using SmartEstate.Infrastructure.Logging;
+using SmartEstate.Infrastructure.MultiTenancy;
 using SmartEstate.Infrastructure.Persistence;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -27,7 +28,6 @@ if (string.IsNullOrWhiteSpace(jwtSecret) || jwtSecret.Length < 32)
 
 builder.Services.AddApplication();
 builder.Services.AddInfrastructure(builder.Configuration);
-builder.Services.AddHttpContextAccessor();
 
 var jwtSettings = builder.Configuration.GetSection("Jwt");
 builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
@@ -75,6 +75,7 @@ app.UseHttpsRedirection();
 app.UseCors("BlazorWasm");
 app.UseAuthentication();
 app.UseAuthorization();
+app.UseMiddleware<TenantMiddleware>();
 app.MapControllers();
 
 app.Run();

--- a/src/SmartEstate.Infrastructure/DependencyInjection.cs
+++ b/src/SmartEstate.Infrastructure/DependencyInjection.cs
@@ -1,4 +1,3 @@
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
@@ -17,7 +16,9 @@ public static class DependencyInjection
         services.Configure<JwtSettings>(configuration.GetSection("Jwt"));
         services.AddScoped<IAuthService, AuthService>();
 
-        services.AddScoped<ITenantContext, TenantContext>();
+        // TenantContext registered both as concrete (for TenantMiddleware setter) and as interface (for all consumers)
+        services.AddScoped<TenantContext>();
+        services.AddScoped<ITenantContext>(sp => sp.GetRequiredService<TenantContext>());
 
         services.AddDbContext<AppDbContext>((sp, options) =>
         {

--- a/src/SmartEstate.Infrastructure/MultiTenancy/TenantMiddleware.cs
+++ b/src/SmartEstate.Infrastructure/MultiTenancy/TenantMiddleware.cs
@@ -1,0 +1,27 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using SmartEstate.Application.Common.Constants;
+using SmartEstate.Infrastructure.Identity;
+using SmartEstate.Infrastructure.Services;
+
+namespace SmartEstate.Infrastructure.MultiTenancy;
+
+public class TenantMiddleware(RequestDelegate next)
+{
+    public async Task InvokeAsync(HttpContext context, TenantContext tenantContext, ILogger<TenantMiddleware> logger)
+    {
+        if (context.User.Identity?.IsAuthenticated == true)
+        {
+            var tenantClaim = context.User.FindFirst(AppClaims.TenantId);
+            if (tenantClaim is not null && Guid.TryParse(tenantClaim.Value, out var tenantId))
+            {
+                tenantContext.TenantId = tenantId;
+                logger.LogDebug("Resolved TenantId {TenantId} for request {Path}", tenantId, context.Request.Path);
+            }
+
+            tenantContext.IsAdministrator = context.User.IsInRole(AppRoles.Administrator);
+        }
+
+        await next(context);
+    }
+}

--- a/src/SmartEstate.Infrastructure/Services/TenantContext.cs
+++ b/src/SmartEstate.Infrastructure/Services/TenantContext.cs
@@ -1,21 +1,9 @@
-using Microsoft.AspNetCore.Http;
-using SmartEstate.Application.Common.Constants;
 using SmartEstate.Application.Common.Interfaces;
-using SmartEstate.Infrastructure.Identity;
 
 namespace SmartEstate.Infrastructure.Services;
 
-public class TenantContext(IHttpContextAccessor httpContextAccessor) : ITenantContext
+public class TenantContext : ITenantContext
 {
-    public Guid? TenantId
-    {
-        get
-        {
-            var claim = httpContextAccessor.HttpContext?.User.FindFirst(AppClaims.TenantId);
-            return claim is not null && Guid.TryParse(claim.Value, out var id) ? id : null;
-        }
-    }
-
-    public bool IsAdministrator =>
-        httpContextAccessor.HttpContext?.User.IsInRole(AppRoles.Administrator) ?? false;
+    public Guid? TenantId { get; set; }
+    public bool IsAdministrator { get; set; }
 }


### PR DESCRIPTION
## Summary
- `TenantContext` refactored to simple mutable POCO — removed `IHttpContextAccessor` dependency
- `TenantMiddleware` runs after `UseAuthorization`, reads `tenant_id` claim, sets `TenantContext.TenantId` and `IsAdministrator`
- DI updated: `TenantContext` registered as concrete scoped service; `ITenantContext` resolves to the same instance — middleware injects concrete type to set values, all other consumers get read-only `ITenantContext`
- Unauthenticated requests pass through silently (TenantId stays null)
- Serilog: logs resolved TenantId at Debug level with request path
- `AddHttpContextAccessor()` removed from Program.cs (no longer needed)

## Deviations from issue spec
- **Middleware in `Infrastructure/MultiTenancy/`** (not `API/Middleware/`) — keeps it co-located with `TenantContext`; both are tenant resolution concerns. API just wires it via `app.UseMiddleware<TenantMiddleware>()`.
- **No explicit setter on `ITenantContext` interface** — middleware injects `TenantContext` (concrete) directly, keeping the interface read-only for all consumers. Same scoped instance guaranteed by DI registration.

## Migration instructions
None required.

Closes #24