### PR TITLE
[Backend] Admin API: POST /admin/tenants — create new tenant

### DIFF
--- a/src/SmartEstate.API/Controllers/AdminTenantsController.cs
+++ b/src/SmartEstate.API/Controllers/AdminTenantsController.cs
@@ -1,0 +1,27 @@
+using ErrorOr;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using SmartEstate.Application.Common.Models;
+using SmartEstate.Application.Features.Admin.Tenants.Commands.CreateTenant;
+using SmartEstate.Application.Features.Admin.Tenants.DTOs;
+using SmartEstate.Infrastructure.Identity;
+
+namespace SmartEstate.API.Controllers;
+
+[ApiController]
+[Route("api/admin/tenants")]
+[Authorize(Roles = AppRoles.Administrator)]
+public class AdminTenantsController(ISender mediator) : ControllerBase
+{
+    [HttpPost]
+    public async Task<IActionResult> Create(CreateTenantCommand command, CancellationToken ct)
+    {
+        var result = await mediator.Send(command, ct);
+        return result.Match(
+            dto => CreatedAtAction(nameof(Create), new { id = dto.Id }, ApiResponse<TenantDto>.Ok(dto)),
+            errors => errors.Any(e => e.Type == ErrorType.Conflict)
+                ? Conflict(ApiResponse.Fail(errors.First().Description))
+                : StatusCode(StatusCodes.Status500InternalServerError, ApiResponse.Fail("An unexpected error occurred.")));
+    }
+}

--- a/src/SmartEstate.Application/Features/Admin/Tenants/Commands/CreateTenant/CreateTenantCommand.cs
+++ b/src/SmartEstate.Application/Features/Admin/Tenants/Commands/CreateTenant/CreateTenantCommand.cs
@@ -1,0 +1,7 @@
+using ErrorOr;
+using MediatR;
+using SmartEstate.Application.Features.Admin.Tenants.DTOs;
+
+namespace SmartEstate.Application.Features.Admin.Tenants.Commands.CreateTenant;
+
+public record CreateTenantCommand(string Name, string ContactEmail, string Plan) : IRequest<ErrorOr<TenantDto>>;

--- a/src/SmartEstate.Application/Features/Admin/Tenants/Commands/CreateTenant/CreateTenantCommandHandler.cs
+++ b/src/SmartEstate.Application/Features/Admin/Tenants/Commands/CreateTenant/CreateTenantCommandHandler.cs
@@ -1,0 +1,36 @@
+using ErrorOr;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using SmartEstate.Application.Common.Interfaces;
+using SmartEstate.Application.Features.Admin.Tenants.DTOs;
+using SmartEstate.Domain.Entities;
+
+namespace SmartEstate.Application.Features.Admin.Tenants.Commands.CreateTenant;
+
+public class CreateTenantCommandHandler(IApplicationDbContext db, ILogger<CreateTenantCommandHandler> logger)
+    : IRequestHandler<CreateTenantCommand, ErrorOr<TenantDto>>
+{
+    public async Task<ErrorOr<TenantDto>> Handle(CreateTenantCommand request, CancellationToken ct)
+    {
+        var exists = await db.Tenants.AnyAsync(t => t.Name == request.Name, ct);
+        if (exists)
+            return Error.Conflict(description: $"A tenant with name '{request.Name}' already exists.");
+
+        var tenant = new Tenant
+        {
+            Name = request.Name,
+            ContactEmail = request.ContactEmail,
+            Plan = request.Plan,
+            IsActive = false
+        };
+
+        db.Tenants.Add(tenant);
+        await db.SaveChangesAsync(ct);
+
+        logger.LogInformation("Tenant {TenantId} ({TenantName}) created with plan {Plan}",
+            tenant.Id, tenant.Name, tenant.Plan);
+
+        return new TenantDto(tenant.Id, tenant.Name, tenant.ContactEmail, tenant.Plan, tenant.IsActive, tenant.CreatedAt);
+    }
+}

--- a/src/SmartEstate.Application/Features/Admin/Tenants/Commands/CreateTenant/CreateTenantCommandValidator.cs
+++ b/src/SmartEstate.Application/Features/Admin/Tenants/Commands/CreateTenant/CreateTenantCommandValidator.cs
@@ -1,0 +1,13 @@
+using FluentValidation;
+
+namespace SmartEstate.Application.Features.Admin.Tenants.Commands.CreateTenant;
+
+public class CreateTenantCommandValidator : AbstractValidator<CreateTenantCommand>
+{
+    public CreateTenantCommandValidator()
+    {
+        RuleFor(x => x.Name).NotEmpty().MaximumLength(200);
+        RuleFor(x => x.ContactEmail).NotEmpty().EmailAddress();
+        RuleFor(x => x.Plan).NotEmpty().MaximumLength(50);
+    }
+}

--- a/src/SmartEstate.Application/Features/Admin/Tenants/DTOs/TenantDto.cs
+++ b/src/SmartEstate.Application/Features/Admin/Tenants/DTOs/TenantDto.cs
@@ -1,0 +1,3 @@
+namespace SmartEstate.Application.Features.Admin.Tenants.DTOs;
+
+public record TenantDto(Guid Id, string Name, string ContactEmail, string? Plan, bool IsActive, DateTime CreatedAt);

--- a/src/SmartEstate.Domain/Entities/Tenant.cs
+++ b/src/SmartEstate.Domain/Entities/Tenant.cs
@@ -6,6 +6,7 @@ public class Tenant : BaseEntity
 {
     public string Name { get; set; } = string.Empty;
     public string ContactEmail { get; set; } = string.Empty;
+    public string? Plan { get; set; }
     public bool IsActive { get; set; } = false;
     public DateTime? ActivatedAt { get; set; }
     public DateTime? DeactivatedAt { get; set; }

--- a/src/SmartEstate.Infrastructure/Persistence/Migrations/20260423132114_AddTenantPlan.Designer.cs
+++ b/src/SmartEstate.Infrastructure/Persistence/Migrations/20260423132114_AddTenantPlan.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SmartEstate.Infrastructure.Persistence;
@@ -12,9 +13,11 @@ using SmartEstate.Infrastructure.Persistence;
 namespace SmartEstate.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260423132114_AddTenantPlan")]
+    partial class AddTenantPlan
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/SmartEstate.Infrastructure/Persistence/Migrations/20260423132114_AddTenantPlan.cs
+++ b/src/SmartEstate.Infrastructure/Persistence/Migrations/20260423132114_AddTenantPlan.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SmartEstate.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTenantPlan : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Plan",
+                table: "Tenants",
+                type: "text",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Plan",
+                table: "Tenants");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- `POST /api/admin/tenants` creates a new tenant record; protected by `[Authorize(Roles = Administrator)]`
- Returns `201 Created` with `ApiResponse<TenantDto>` (id, name, contactEmail, plan, isActive, createdAt)
- Returns `409 Conflict` if a tenant with the same name already exists
- Returns `400 Bad Request` for validation errors (missing name, invalid email, missing plan)
- New tenant always created with `IsActive = false`

## Deviations from issue spec
- **Migration was required** despite the issue saying otherwise — `Tenant.Plan` was not in the Sprint 0 schema. Added as a nullable column (`string?`) so existing rows are unaffected. Migration: `20260423132114_AddTenantPlan`.

## Migration instructions
Run after merge:
```
dotnet ef database update --project src/SmartEstate.Infrastructure --startup-project src/SmartEstate.API
```

## Follow-up
- `#28` (POST /admin/tenants/{id}/users) and `#29` (PATCH /admin/tenants/{id}/activate) will be added as actions on `AdminTenantsController`.

Closes #27