### PR TITLE
[Backend] Block requests from inactive tenants — 403 middleware

### DIFF
--- a/src/SmartEstate.API/Program.cs
+++ b/src/SmartEstate.API/Program.cs
@@ -76,6 +76,7 @@ app.UseCors("BlazorWasm");
 app.UseAuthentication();
 app.UseAuthorization();
 app.UseMiddleware<TenantMiddleware>();
+app.UseMiddleware<InactiveTenantMiddleware>();
 app.MapControllers();
 
 app.Run();

--- a/src/SmartEstate.Infrastructure/DependencyInjection.cs
+++ b/src/SmartEstate.Infrastructure/DependencyInjection.cs
@@ -28,6 +28,7 @@ public static class DependencyInjection
 
         services.AddScoped<IApplicationDbContext>(sp => sp.GetRequiredService<AppDbContext>());
         services.AddScoped<DataSeeder>();
+        services.AddMemoryCache();
 
         services.AddIdentity<ApplicationUser, ApplicationRole>(options =>
             {

--- a/src/SmartEstate.Infrastructure/MultiTenancy/InactiveTenantMiddleware.cs
+++ b/src/SmartEstate.Infrastructure/MultiTenancy/InactiveTenantMiddleware.cs
@@ -1,0 +1,54 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using SmartEstate.Application.Common.Interfaces;
+using SmartEstate.Application.Common.Models;
+
+namespace SmartEstate.Infrastructure.MultiTenancy;
+
+public class InactiveTenantMiddleware(RequestDelegate next)
+{
+    public async Task InvokeAsync(
+        HttpContext context,
+        ITenantContext tenantContext,
+        IApplicationDbContext db,
+        IMemoryCache cache,
+        ILogger<InactiveTenantMiddleware> logger)
+    {
+        // Skip: unauthenticated, Administrator (no TenantId), or health/ping endpoints
+        if (tenantContext.TenantId is null
+            || context.Request.Path.StartsWithSegments("/health", StringComparison.OrdinalIgnoreCase)
+            || context.Request.Path.StartsWithSegments("/ping", StringComparison.OrdinalIgnoreCase))
+        {
+            await next(context);
+            return;
+        }
+
+        var tenantId = tenantContext.TenantId.Value;
+        var cacheKey = $"tenant_active_{tenantId}";
+
+        if (!cache.TryGetValue(cacheKey, out bool isActive))
+        {
+            isActive = await db.Tenants
+                .AsNoTracking()
+                .Where(t => t.Id == tenantId)
+                .Select(t => t.IsActive)
+                .FirstOrDefaultAsync(context.RequestAborted);
+
+            cache.Set(cacheKey, isActive, TimeSpan.FromSeconds(60));
+        }
+
+        if (!isActive)
+        {
+            logger.LogWarning("Blocked request from inactive tenant {TenantId} to {Path}", tenantId, context.Request.Path);
+            context.Response.StatusCode = StatusCodes.Status403Forbidden;
+            await context.Response.WriteAsJsonAsync(
+                ApiResponse.Fail("Tenant account is inactive. Please contact your administrator."),
+                context.RequestAborted);
+            return;
+        }
+
+        await next(context);
+    }
+}


### PR DESCRIPTION
## Summary
- `InactiveTenantMiddleware` runs immediately after `TenantMiddleware` in the pipeline
- Checks `Tenant.IsActive` from DB; result cached 60s in `IMemoryCache` (key: `tenant_active_{tenantId}`)
- Returns `403 Forbidden` with `ApiResponse.Fail("Tenant account is inactive. Please contact your administrator.")` for inactive tenants
- Skips check when: `TenantId` is null (Administrator), request is unauthenticated, path starts with `/health` or `/ping`
- `services.AddMemoryCache()` added to Infrastructure DI

## Pipeline order in Program.cs
```
UseAuthentication → UseAuthorization → TenantMiddleware → InactiveTenantMiddleware → controllers
```

## Migration instructions
None required.

Closes #26