### PR TITLE
[Backend] Admin API: PATCH /admin/tenants/{id}/activate — toggle tenant IsActive flag

### DIFF
--- a/src/SmartEstate.API/Controllers/AdminTenantsController.cs
+++ b/src/SmartEstate.API/Controllers/AdminTenantsController.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Mvc;
 using SmartEstate.API.Models.Requests;
 using SmartEstate.Application.Common.Models;
 using SmartEstate.Application.Features.Admin.Tenants.Commands.CreateTenant;
+using SmartEstate.Application.Features.Admin.Tenants.Commands.SetTenantActive;
 using SmartEstate.Application.Features.Admin.Tenants.DTOs;
 using SmartEstate.Application.Features.Admin.Users.Commands.CreateTenantUser;
 using SmartEstate.Application.Features.Admin.Users.DTOs;
@@ -36,6 +37,18 @@ public class AdminTenantsController(ISender mediator) : ControllerBase
         var result = await mediator.Send(command, ct);
         return result.Match(
             dto => CreatedAtAction(nameof(CreateUser), new { tenantId, id = dto.Id }, ApiResponse<UserDto>.Ok(dto)),
+            errors => MapErrors(errors));
+    }
+
+    [HttpPatch("{tenantId:guid}/activate")]
+    public async Task<IActionResult> SetActive(
+        Guid tenantId,
+        [FromBody] SetTenantActiveRequest body,
+        CancellationToken ct)
+    {
+        var result = await mediator.Send(new SetTenantActiveCommand(tenantId, body.IsActive), ct);
+        return result.Match(
+            dto => Ok(ApiResponse<TenantDto>.Ok(dto)),
             errors => MapErrors(errors));
     }
 

--- a/src/SmartEstate.API/Models/Requests/SetTenantActiveRequest.cs
+++ b/src/SmartEstate.API/Models/Requests/SetTenantActiveRequest.cs
@@ -1,0 +1,3 @@
+namespace SmartEstate.API.Models.Requests;
+
+public record SetTenantActiveRequest(bool IsActive);

--- a/src/SmartEstate.Application/Common/Interfaces/ITenantCache.cs
+++ b/src/SmartEstate.Application/Common/Interfaces/ITenantCache.cs
@@ -1,0 +1,6 @@
+namespace SmartEstate.Application.Common.Interfaces;
+
+public interface ITenantCache
+{
+    void InvalidateTenant(Guid tenantId);
+}

--- a/src/SmartEstate.Application/Features/Admin/Tenants/Commands/SetTenantActive/SetTenantActiveCommand.cs
+++ b/src/SmartEstate.Application/Features/Admin/Tenants/Commands/SetTenantActive/SetTenantActiveCommand.cs
@@ -1,0 +1,7 @@
+using ErrorOr;
+using MediatR;
+using SmartEstate.Application.Features.Admin.Tenants.DTOs;
+
+namespace SmartEstate.Application.Features.Admin.Tenants.Commands.SetTenantActive;
+
+public record SetTenantActiveCommand(Guid TenantId, bool IsActive) : IRequest<ErrorOr<TenantDto>>;

--- a/src/SmartEstate.Application/Features/Admin/Tenants/Commands/SetTenantActive/SetTenantActiveCommandHandler.cs
+++ b/src/SmartEstate.Application/Features/Admin/Tenants/Commands/SetTenantActive/SetTenantActiveCommandHandler.cs
@@ -1,0 +1,34 @@
+using ErrorOr;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using SmartEstate.Application.Common.Interfaces;
+using SmartEstate.Application.Features.Admin.Tenants.DTOs;
+
+namespace SmartEstate.Application.Features.Admin.Tenants.Commands.SetTenantActive;
+
+public class SetTenantActiveCommandHandler(
+    IApplicationDbContext db,
+    ITenantCache tenantCache,
+    ILogger<SetTenantActiveCommandHandler> logger)
+    : IRequestHandler<SetTenantActiveCommand, ErrorOr<TenantDto>>
+{
+    public async Task<ErrorOr<TenantDto>> Handle(SetTenantActiveCommand request, CancellationToken ct)
+    {
+        var tenant = await db.Tenants
+            .FirstOrDefaultAsync(t => t.Id == request.TenantId, ct);
+
+        if (tenant is null)
+            return Error.NotFound(description: $"Tenant {request.TenantId} not found.");
+
+        tenant.IsActive = request.IsActive;
+        await db.SaveChangesAsync(ct);
+
+        tenantCache.InvalidateTenant(request.TenantId);
+
+        logger.LogInformation("Tenant {TenantId} {Action}",
+            request.TenantId, request.IsActive ? "activated" : "deactivated");
+
+        return new TenantDto(tenant.Id, tenant.Name, tenant.ContactEmail, tenant.Plan, tenant.IsActive, tenant.CreatedAt);
+    }
+}

--- a/src/SmartEstate.Infrastructure/DependencyInjection.cs
+++ b/src/SmartEstate.Infrastructure/DependencyInjection.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using SmartEstate.Application.Common.Interfaces;
 using SmartEstate.Infrastructure.Identity;
+using SmartEstate.Infrastructure.MultiTenancy;
 using SmartEstate.Infrastructure.Persistence;
 using SmartEstate.Infrastructure.Services;
 
@@ -30,6 +31,7 @@ public static class DependencyInjection
         services.AddScoped<IApplicationDbContext>(sp => sp.GetRequiredService<AppDbContext>());
         services.AddScoped<DataSeeder>();
         services.AddMemoryCache();
+        services.AddScoped<ITenantCache, TenantCache>();
 
         services.AddIdentity<ApplicationUser, ApplicationRole>(options =>
             {

--- a/src/SmartEstate.Infrastructure/MultiTenancy/TenantCache.cs
+++ b/src/SmartEstate.Infrastructure/MultiTenancy/TenantCache.cs
@@ -1,0 +1,10 @@
+using Microsoft.Extensions.Caching.Memory;
+using SmartEstate.Application.Common.Interfaces;
+
+namespace SmartEstate.Infrastructure.MultiTenancy;
+
+public class TenantCache(IMemoryCache cache) : ITenantCache
+{
+    public void InvalidateTenant(Guid tenantId)
+        => cache.Remove($"tenant_active_{tenantId}");
+}


### PR DESCRIPTION
## Summary
- `PATCH /api/admin/tenants/{tenantId}/activate` accepts `{ isActive: bool }`, updates `Tenant.IsActive`
- Returns `200 OK` with `ApiResponse<TenantDto>` reflecting updated state; `404` if tenant not found
- Cache entry `tenant_active_{tenantId}` invalidated immediately via `ITenantCache` so `InactiveTenantMiddleware` picks up the change within the same request cycle

## Architecture notes
- `ITenantCache` interface defined in Application (single method: `InvalidateTenant(Guid)`)
- `TenantCache` in `Infrastructure/MultiTenancy/` wraps `IMemoryCache.Remove` — keeps cache key format co-located with `InactiveTenantMiddleware`
- Handler injects `ITenantCache` from Application, not `IMemoryCache` directly — maintains Application layer independence from caching infrastructure

## Migration instructions
None required.

Closes #29