### PR TITLE
[Frontend] Fix _isDarkMode default — prevent dark flash on first load

### DIFF
--- a/src/SmartEstate.Web/Layout/MainLayout.razor
+++ b/src/SmartEstate.Web/Layout/MainLayout.razor
@@ -40,7 +40,7 @@
 
 @code {
     private MudThemeProvider _themeProvider = null!;
-    private bool _isDarkMode = true;
+    private bool _isDarkMode = false;
     private bool _drawerOpen = true;
 
     private readonly MudTheme _theme = new()


### PR DESCRIPTION
## Summary
- Changes `_isDarkMode` field initializer from `true` to `false` in `MainLayout.razor`
- Eliminates the dark→light flash on first load when no localStorage preference is set
- `OnAfterRenderAsync` already defaults to `false` via `stored ?? false` — field initializer now matches

## Test plan
- [ ] Clear localStorage, open app — loads in light mode with no flash
- [ ] Toggle to dark mode, refresh — dark mode persists correctly
- [ ] Toggle back to light, refresh — light mode persists correctly

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)