### PR TITLE
[Frontend] Implement JwtAuthStateProvider — custom AuthenticationStateProvider for Blazor WASM

### DIFF
--- a/.claude/frontend-dev.md
+++ b/.claude/frontend-dev.md
@@ -257,9 +257,14 @@ PR description must include:
 
 ## Implementation Notes & Discoveries
 
-*(Update this section as you implement features)*
-
-- API base URL for local dev: `https://localhost:7001`  
+- API base URL for local dev: `https://localhost:7001`
 - MudBlazor requires `<MudThemeProvider>`, `<MudDialogProvider>`, `<MudSnackbarProvider>` in `MainLayout.razor` or `App.razor`
 - Blazor WASM auth: JWT claims are parsed from the token payload by `JwtAuthStateProvider` — no separate user-info endpoint needed
 - For file uploads (property images): use `IBrowserFile` with `MudFileUpload` — send as `multipart/form-data` to API
+- `JwtAuthStateProvider` double-registration pattern (required so Login page can inject the concrete type for `Login()`/`Logout()` while the framework resolves `AuthenticationStateProvider`):
+  ```csharp
+  builder.Services.AddScoped<JwtAuthStateProvider>();
+  builder.Services.AddScoped<AuthenticationStateProvider>(sp => sp.GetRequiredService<JwtAuthStateProvider>());
+  ```
+- JWT localStorage key: `"smartestate_jwt"` — must match across `JwtAuthStateProvider`, Login page, and `ApiClient`
+- Theme localStorage key: `"smartestate_dark_mode"` — `_isDarkMode` field initializer must be `false` (matches `stored ?? false` in `OnAfterRenderAsync`)

--- a/src/SmartEstate.Web/Auth/JwtAuthStateProvider.cs
+++ b/src/SmartEstate.Web/Auth/JwtAuthStateProvider.cs
@@ -1,0 +1,99 @@
+using System.Security.Claims;
+using System.Text.Json;
+using Blazored.LocalStorage;
+using Microsoft.AspNetCore.Components.Authorization;
+
+namespace SmartEstate.Web.Auth;
+
+public class JwtAuthStateProvider : AuthenticationStateProvider
+{
+    private const string TokenKey = "smartestate_jwt";
+    private static readonly AuthenticationState AnonymousState =
+        new(new ClaimsPrincipal(new ClaimsIdentity()));
+
+    private readonly ILocalStorageService _localStorage;
+
+    public JwtAuthStateProvider(ILocalStorageService localStorage)
+    {
+        _localStorage = localStorage;
+    }
+
+    public override async Task<AuthenticationState> GetAuthenticationStateAsync()
+    {
+        var token = await _localStorage.GetItemAsStringAsync(TokenKey);
+        if (string.IsNullOrWhiteSpace(token))
+            return AnonymousState;
+
+        var claims = ParseClaimsFromJwt(token);
+        if (IsTokenExpired(claims))
+        {
+            await _localStorage.RemoveItemAsync(TokenKey);
+            return AnonymousState;
+        }
+
+        var identity = new ClaimsIdentity(claims, "jwt");
+        return new AuthenticationState(new ClaimsPrincipal(identity));
+    }
+
+    public async Task Login(string token)
+    {
+        await _localStorage.SetItemAsStringAsync(TokenKey, token);
+        var claims = ParseClaimsFromJwt(token);
+        var identity = new ClaimsIdentity(claims, "jwt");
+        NotifyAuthenticationStateChanged(
+            Task.FromResult(new AuthenticationState(new ClaimsPrincipal(identity))));
+    }
+
+    public async Task Logout()
+    {
+        await _localStorage.RemoveItemAsync(TokenKey);
+        NotifyAuthenticationStateChanged(Task.FromResult(AnonymousState));
+    }
+
+    private static IEnumerable<Claim> ParseClaimsFromJwt(string jwt)
+    {
+        var payload = jwt.Split('.')[1];
+        var jsonBytes = DecodeBase64Url(payload);
+        var kvp = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(jsonBytes)!;
+
+        var claims = new List<Claim>();
+        foreach (var (key, value) in kvp)
+        {
+            var type = key switch
+            {
+                "sub" => ClaimTypes.NameIdentifier,
+                "email" => ClaimTypes.Email,
+                "role" => ClaimTypes.Role,
+                _ => key
+            };
+
+            if (value.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var el in value.EnumerateArray())
+                    claims.Add(new Claim(type, el.GetString() ?? ""));
+            }
+            else
+            {
+                claims.Add(new Claim(type, value.GetString() ?? value.GetRawText()));
+            }
+        }
+
+        return claims;
+    }
+
+    private static bool IsTokenExpired(IEnumerable<Claim> claims)
+    {
+        var expClaim = claims.FirstOrDefault(c => c.Type == "exp");
+        if (expClaim is null || !long.TryParse(expClaim.Value, out var exp))
+            return true;
+
+        return DateTimeOffset.FromUnixTimeSeconds(exp) < DateTimeOffset.UtcNow;
+    }
+
+    private static byte[] DecodeBase64Url(string base64Url)
+    {
+        var base64 = base64Url.Replace('-', '+').Replace('_', '/');
+        base64 = base64.PadRight(base64.Length + (4 - base64.Length % 4) % 4, '=');
+        return Convert.FromBase64String(base64);
+    }
+}

--- a/src/SmartEstate.Web/Program.cs
+++ b/src/SmartEstate.Web/Program.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using MudBlazor.Services;
 using SmartEstate.Web;
+using SmartEstate.Web.Auth;
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
 builder.RootComponents.Add<App>("#app");
@@ -17,5 +18,9 @@ builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(apiBaseU
 builder.Services.AddBlazoredLocalStorage();
 builder.Services.AddMudServices();
 builder.Services.AddAuthorizationCore();
+
+builder.Services.AddScoped<JwtAuthStateProvider>();
+builder.Services.AddScoped<AuthenticationStateProvider>(
+    sp => sp.GetRequiredService<JwtAuthStateProvider>());
 
 await builder.Build().RunAsync();


### PR DESCRIPTION
## Summary
- `Auth/JwtAuthStateProvider.cs` — custom `AuthenticationStateProvider` that reads JWT from localStorage
- Manual Base64Url payload decode → `ClaimsPrincipal` (no external JWT library)
- Claim mapping: `sub`→`ClaimTypes.NameIdentifier`, `email`→`ClaimTypes.Email`, `role`→`ClaimTypes.Role`, `tenant_id`→`"tenant_id"`
- `Login(token)` / `Logout()` methods with `NotifyAuthenticationStateChanged`
- Expired token (`exp` claim < now) returns anonymous state and removes token from storage
- Registered as both `JwtAuthStateProvider` (concrete) and `AuthenticationStateProvider` (abstraction) so Login page can inject the concrete type directly

## Test plan
- [ ] `[Authorize]` pages redirect to `/login` when no token in localStorage
- [ ] After login token is stored under `smartestate_jwt`, auth state reflects correct role claims
- [ ] Expired token is removed and treated as anonymous on next load

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)