### PR TITLE
[Frontend] Implement Login page — MudBlazor form with JWT auth flow

### DIFF
--- a/src/SmartEstate.Web/Layout/EmptyLayout.razor
+++ b/src/SmartEstate.Web/Layout/EmptyLayout.razor
@@ -1,0 +1,24 @@
+@inherits LayoutComponentBase
+
+<MudThemeProvider Theme="_theme" />
+<MudPopoverProvider />
+<MudDialogProvider />
+<MudSnackbarProvider />
+
+<MudLayout>
+    <MudMainContent>
+        @Body
+    </MudMainContent>
+</MudLayout>
+
+@code {
+    private readonly MudTheme _theme = new()
+    {
+        PaletteLight = new PaletteLight
+        {
+            Primary = "#1976D2",
+            Secondary = "#FF5722",
+            AppbarBackground = "#1976D2",
+        }
+    };
+}

--- a/src/SmartEstate.Web/Models/Auth/LoginResponseDto.cs
+++ b/src/SmartEstate.Web/Models/Auth/LoginResponseDto.cs
@@ -1,0 +1,3 @@
+namespace SmartEstate.Web.Models.Auth;
+
+public record LoginResponseDto(string Token, DateTimeOffset ExpiresAt, string Role, Guid? TenantId);

--- a/src/SmartEstate.Web/Models/Common/ApiResponse.cs
+++ b/src/SmartEstate.Web/Models/Common/ApiResponse.cs
@@ -1,0 +1,16 @@
+namespace SmartEstate.Web.Models.Common;
+
+public class ApiResponse<T>
+{
+    public bool Success { get; init; }
+    public T? Data { get; init; }
+    public string? Message { get; init; }
+    public IEnumerable<string>? Errors { get; init; }
+}
+
+public class ApiResponse
+{
+    public bool Success { get; init; }
+    public string? Message { get; init; }
+    public IEnumerable<string>? Errors { get; init; }
+}

--- a/src/SmartEstate.Web/Pages/Auth/Login.razor
+++ b/src/SmartEstate.Web/Pages/Auth/Login.razor
@@ -1,0 +1,116 @@
+@page "/login"
+@layout EmptyLayout
+@inject AuthService AuthService
+@inject NavigationManager Nav
+@inject AuthenticationStateProvider AuthStateProvider
+
+<PageTitle>Sign In — SmartEstate</PageTitle>
+
+<MudContainer MaxWidth="MaxWidth.Small" Class="d-flex align-center justify-center" Style="min-height: 100vh;">
+    <MudPaper Elevation="4" Class="pa-8" Style="width: 100%; max-width: 420px;">
+        <MudText Typo="Typo.h5" Align="Align.Center" Class="mb-6">
+            <b>SmartEstate</b>
+        </MudText>
+
+        <MudText Typo="Typo.subtitle1" Align="Align.Center" Class="mb-6 mud-text-secondary">
+            Sign in to your account
+        </MudText>
+
+        @if (_error is not null)
+        {
+            <MudAlert Severity="Severity.Error" Class="mb-4" Dense="true">@_error</MudAlert>
+        }
+
+        <MudForm @ref="_form" @bind-IsValid="_isFormValid">
+            <MudTextField T="string"
+                          @bind-Value="_email"
+                          Label="Email"
+                          InputType="InputType.Email"
+                          Required="true"
+                          RequiredError="Email is required."
+                          Validation="@(new EmailAddressAttribute())"
+                          Adornment="Adornment.Start"
+                          AdornmentIcon="@Icons.Material.Filled.Email"
+                          Class="mb-3" />
+
+            <MudTextField T="string"
+                          @bind-Value="_password"
+                          Label="Password"
+                          InputType="InputType.Password"
+                          Required="true"
+                          RequiredError="Password is required."
+                          Adornment="Adornment.Start"
+                          AdornmentIcon="@Icons.Material.Filled.Lock"
+                          Class="mb-6" />
+
+            <MudButton Variant="Variant.Filled"
+                       Color="Color.Primary"
+                       FullWidth="true"
+                       Size="Size.Large"
+                       Disabled="_isLoading"
+                       OnClick="HandleLogin">
+                @if (_isLoading)
+                {
+                    <MudProgressCircular Size="Size.Small" Indeterminate="true" Class="mr-2" />
+                    <span>Signing in...</span>
+                }
+                else
+                {
+                    <span>Sign In</span>
+                }
+            </MudButton>
+        </MudForm>
+    </MudPaper>
+</MudContainer>
+
+@code {
+    [SupplyParameterFromQuery]
+    private string? ReturnUrl { get; set; }
+
+    private MudForm _form = null!;
+    private string _email = string.Empty;
+    private string _password = string.Empty;
+    private bool _isLoading;
+    private bool _isFormValid;
+    private string? _error;
+
+    protected override async Task OnInitializedAsync()
+    {
+        var state = await AuthStateProvider.GetAuthenticationStateAsync();
+        if (state.User.Identity?.IsAuthenticated == true)
+            Nav.NavigateTo(GetReturnUrl(), replace: true);
+    }
+
+    private async Task HandleLogin()
+    {
+        await _form.ValidateAsync();
+        if (!_isFormValid) return;
+
+        _isLoading = true;
+        _error = null;
+
+        var result = await AuthService.LoginAsync(_email, _password);
+
+        _isLoading = false;
+
+        switch (result)
+        {
+            case LoginResult.Success:
+                Nav.NavigateTo(GetReturnUrl(), replace: true);
+                break;
+            case LoginResult.Unauthorized:
+                _error = "Invalid email or password.";
+                break;
+            default:
+                _error = "An error occurred. Please try again.";
+                break;
+        }
+    }
+
+    private string GetReturnUrl()
+    {
+        if (string.IsNullOrWhiteSpace(ReturnUrl)) return "/";
+        var decoded = Uri.UnescapeDataString(ReturnUrl);
+        return decoded.StartsWith('/') ? decoded : "/";
+    }
+}

--- a/src/SmartEstate.Web/Program.cs
+++ b/src/SmartEstate.Web/Program.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using MudBlazor.Services;
 using SmartEstate.Web;
 using SmartEstate.Web.Auth;
+using SmartEstate.Web.Services;
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
 builder.RootComponents.Add<App>("#app");
@@ -22,5 +23,8 @@ builder.Services.AddAuthorizationCore();
 builder.Services.AddScoped<JwtAuthStateProvider>();
 builder.Services.AddScoped<AuthenticationStateProvider>(
     sp => sp.GetRequiredService<JwtAuthStateProvider>());
+
+builder.Services.AddScoped<ApiClient>();
+builder.Services.AddScoped<AuthService>();
 
 await builder.Build().RunAsync();

--- a/src/SmartEstate.Web/Services/ApiClient.cs
+++ b/src/SmartEstate.Web/Services/ApiClient.cs
@@ -1,0 +1,55 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using Blazored.LocalStorage;
+using Microsoft.AspNetCore.Components;
+using SmartEstate.Web.Models.Common;
+
+namespace SmartEstate.Web.Services;
+
+public class ApiClient(HttpClient http, ILocalStorageService localStorage, NavigationManager nav)
+{
+    private const string TokenKey = "smartestate_jwt";
+
+    public Task<ApiResponse<T>?> GetAsync<T>(string url) =>
+        SendAsync<T>(HttpMethod.Get, url, body: null);
+
+    public Task<ApiResponse<T>?> PostAsync<T>(string url, object body) =>
+        SendAsync<T>(HttpMethod.Post, url, body);
+
+    public Task<ApiResponse<T>?> PatchAsync<T>(string url, object body) =>
+        SendAsync<T>(HttpMethod.Patch, url, body);
+
+    public Task<ApiResponse<T>?> DeleteAsync<T>(string url) =>
+        SendAsync<T>(HttpMethod.Delete, url, body: null);
+
+    private async Task<ApiResponse<T>?> SendAsync<T>(HttpMethod method, string url, object? body)
+    {
+        var request = new HttpRequestMessage(method, url);
+
+        var token = await localStorage.GetItemAsStringAsync(TokenKey);
+        if (!string.IsNullOrEmpty(token))
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+        if (body is not null)
+            request.Content = JsonContent.Create(body);
+
+        try
+        {
+            var response = await http.SendAsync(request);
+
+            if (response.StatusCode == HttpStatusCode.Unauthorized)
+            {
+                await localStorage.RemoveItemAsync(TokenKey);
+                nav.NavigateTo("/login", forceLoad: false);
+                return null;
+            }
+
+            return await response.Content.ReadFromJsonAsync<ApiResponse<T>>();
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}

--- a/src/SmartEstate.Web/Services/AuthService.cs
+++ b/src/SmartEstate.Web/Services/AuthService.cs
@@ -1,0 +1,36 @@
+using System.Net;
+using System.Net.Http.Json;
+using SmartEstate.Web.Auth;
+using SmartEstate.Web.Models.Auth;
+using SmartEstate.Web.Models.Common;
+
+namespace SmartEstate.Web.Services;
+
+public enum LoginResult { Success, Unauthorized, Error }
+
+public class AuthService(HttpClient http, JwtAuthStateProvider authProvider)
+{
+    public async Task<LoginResult> LoginAsync(string email, string password)
+    {
+        try
+        {
+            var response = await http.PostAsJsonAsync("api/auth/login", new { email, password });
+
+            if (response.StatusCode == HttpStatusCode.Unauthorized)
+                return LoginResult.Unauthorized;
+
+            var apiResponse = await response.Content.ReadFromJsonAsync<ApiResponse<LoginResponseDto>>();
+            if (apiResponse?.Success != true || apiResponse.Data is null)
+                return LoginResult.Error;
+
+            await authProvider.Login(apiResponse.Data.Token);
+            return LoginResult.Success;
+        }
+        catch
+        {
+            return LoginResult.Error;
+        }
+    }
+
+    public Task LogoutAsync() => authProvider.Logout();
+}

--- a/src/SmartEstate.Web/_Imports.razor
+++ b/src/SmartEstate.Web/_Imports.razor
@@ -13,3 +13,7 @@
 @using SmartEstate.Web
 @using SmartEstate.Web.Layout
 @using SmartEstate.Web.Auth
+@using SmartEstate.Web.Services
+@using SmartEstate.Web.Models.Auth
+@using SmartEstate.Web.Models.Common
+@using System.ComponentModel.DataAnnotations


### PR DESCRIPTION
## Summary
- `Layout/EmptyLayout.razor` — bare layout (no app bar, no drawer) used by the login page
- `Models/Common/ApiResponse.cs` — client-side mirror of backend `ApiResponse<T>` wrapper
- `Models/Auth/LoginResponseDto.cs` — mirrors `LoginResponseDto` from backend (`Token`, `ExpiresAt`, `Role`, `TenantId`)
- `Services/ApiClient.cs` — JWT-aware HTTP wrapper; attaches `Bearer` token per-request, handles 401 by clearing token and redirecting to `/login`
- `Services/AuthService.cs` — `LoginAsync(email, password)` → returns `LoginResult` enum (`Success`, `Unauthorized`, `Error`); `LogoutAsync()`
- `Pages/Auth/Login.razor` — centered `MudPaper` card, `MudForm` with email + password fields, inline error `MudAlert`, loading state on submit button, redirect to `returnUrl` on success, redirect away if already authenticated

## API contract
- `POST /api/auth/login` body: `{ email, password }` — response: `ApiResponse<LoginResponseDto>`
- 401 Unauthorized → "Invalid email or password."
- Network/server error → "An error occurred. Please try again."

## Test plan
- [ ] Unauthenticated user visits any page → redirected to `/login`
- [ ] Submit with empty fields → inline validation errors, no API call
- [ ] Wrong credentials → "Invalid email or password." alert
- [ ] Correct credentials → JWT stored in localStorage under `smartestate_jwt`, redirected to `/` (or `returnUrl`)
- [ ] Visit `/login` while already authenticated → redirected to `/` immediately

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)