### PR TITLE
[Frontend] Admin tenants panel

### DIFF
--- a/.claude/frontend-dev.md
+++ b/.claude/frontend-dev.md
@@ -268,3 +268,6 @@ PR description must include:
   ```
 - JWT localStorage key: `"smartestate_jwt"` — must match across `JwtAuthStateProvider`, Login page, and `ApiClient`
 - Theme localStorage key: `"smartestate_dark_mode"` — `_isDarkMode` field initializer must be `false` (matches `stored ?? false` in `OnAfterRenderAsync`)
+- Admin tenant management page lives at `Pages/Admin/Tenants.razor` and is protected with `[Authorize(Roles = "Administrator")]`.
+- Use `TenantAdminService` for admin tenant HTTP calls and register it in `Program.cs`; it wraps `ApiClient` calls to `api/admin/tenants`.
+- Admin navigation entries must be wrapped in `<AuthorizeView Roles="Administrator">`; `/admin/tenants` is listed under the "Administration" nav group.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -288,10 +288,10 @@ Owner reviews milestone → plans next sprint with Lead Dev
 **Frontend tasks:**
 | # | GitHub Issue | Task | Label | Status |
 |---|---|---|---|---|
-| 1.8 | [#30](https://github.com/LazarVujosevic/SmartEstate/issues/30) | `JwtAuthStateProvider` — custom `AuthenticationStateProvider` | `frontend` | 🔲 Open |
-| 1.9 | [#31](https://github.com/LazarVujosevic/SmartEstate/issues/31) | Login page — MudBlazor form, JWT stored in localStorage | `frontend` | 🔲 Open |
-| 1.10 | [#32](https://github.com/LazarVujosevic/SmartEstate/issues/32) | Fix `_isDarkMode` field initializer in `MainLayout.razor` | `frontend` | 🔲 Open |
-| 1.11 | [#33](https://github.com/LazarVujosevic/SmartEstate/issues/33) | Admin panel — tenant list, create form, activation toggle | `frontend` | 🔲 Open |
+| 1.8 | [#30](https://github.com/LazarVujosevic/SmartEstate/issues/30) | `JwtAuthStateProvider` — custom `AuthenticationStateProvider` | `frontend` | ✅ Done |
+| 1.9 | [#31](https://github.com/LazarVujosevic/SmartEstate/issues/31) | Login page — MudBlazor form, JWT stored in localStorage | `frontend` | ✅ Done |
+| 1.10 | [#32](https://github.com/LazarVujosevic/SmartEstate/issues/32) | Fix `_isDarkMode` field initializer in `MainLayout.razor` | `frontend` | ✅ Done |
+| 1.11 | [#33](https://github.com/LazarVujosevic/SmartEstate/issues/33) | Admin panel — tenant list, create form, activation toggle | `frontend` | ✅ Done |
 
 ---
 
@@ -538,6 +538,8 @@ Owner reviews milestone → plans next sprint with Lead Dev
 - MudBlazor 9.x: required providers in layout are `MudThemeProvider`, `MudPopoverProvider`, `MudDialogProvider`, `MudSnackbarProvider` — all four must be present or dropdowns/dialogs/snackbars will silently fail
 - Theme preference is stored in `localStorage` under key `smartestate_dark_mode` (bool) — read in `OnAfterRenderAsync`, not `OnInitializedAsync` (localStorage is unavailable during prerender)
 - `AuthorizeRouteView` + `RedirectToLogin` are already wired in `App.razor` — Sprint 1 Frontend only needs to register `JwtAuthStateProvider` and build the Login page
+- Admin tenant management uses `TenantAdminService` over `ApiClient` for `GET/POST/PATCH api/admin/tenants`; register feature-specific frontend services in `Program.cs`
+- Administrator-only navigation links belong inside `<AuthorizeView Roles="Administrator">`; current admin entry point is `/admin/tenants`
 - Gemini API has rate limits on free tier — batch AI requests where possible, avoid per-request calls in loops
 - Windows Server production deployment: use IIS reverse proxy for API + publish Blazor WASM as static files
 

--- a/src/SmartEstate.API/Controllers/AdminTenantsController.cs
+++ b/src/SmartEstate.API/Controllers/AdminTenantsController.cs
@@ -7,6 +7,7 @@ using SmartEstate.Application.Common.Models;
 using SmartEstate.Application.Features.Admin.Tenants.Commands.CreateTenant;
 using SmartEstate.Application.Features.Admin.Tenants.Commands.SetTenantActive;
 using SmartEstate.Application.Features.Admin.Tenants.DTOs;
+using SmartEstate.Application.Features.Admin.Tenants.Queries.GetTenants;
 using SmartEstate.Application.Features.Admin.Users.Commands.CreateTenantUser;
 using SmartEstate.Application.Features.Admin.Users.DTOs;
 using SmartEstate.Infrastructure.Identity;
@@ -18,6 +19,15 @@ namespace SmartEstate.API.Controllers;
 [Authorize(Roles = AppRoles.Administrator)]
 public class AdminTenantsController(ISender mediator) : ControllerBase
 {
+    [HttpGet]
+    public async Task<IActionResult> GetAll(CancellationToken ct)
+    {
+        var result = await mediator.Send(new GetTenantsQuery(), ct);
+        return result.Match(
+            list => Ok(ApiResponse<List<TenantDto>>.Ok(list)),
+            errors => MapErrors(errors));
+    }
+
     [HttpPost]
     public async Task<IActionResult> Create(CreateTenantCommand command, CancellationToken ct)
     {

--- a/src/SmartEstate.Application/Features/Admin/Tenants/Queries/GetTenants/GetTenantsQuery.cs
+++ b/src/SmartEstate.Application/Features/Admin/Tenants/Queries/GetTenants/GetTenantsQuery.cs
@@ -1,0 +1,7 @@
+using ErrorOr;
+using MediatR;
+using SmartEstate.Application.Features.Admin.Tenants.DTOs;
+
+namespace SmartEstate.Application.Features.Admin.Tenants.Queries.GetTenants;
+
+public record GetTenantsQuery : IRequest<ErrorOr<List<TenantDto>>>;

--- a/src/SmartEstate.Application/Features/Admin/Tenants/Queries/GetTenants/GetTenantsQueryHandler.cs
+++ b/src/SmartEstate.Application/Features/Admin/Tenants/Queries/GetTenants/GetTenantsQueryHandler.cs
@@ -1,0 +1,22 @@
+using ErrorOr;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using SmartEstate.Application.Common.Interfaces;
+using SmartEstate.Application.Features.Admin.Tenants.DTOs;
+
+namespace SmartEstate.Application.Features.Admin.Tenants.Queries.GetTenants;
+
+public class GetTenantsQueryHandler(IApplicationDbContext db)
+    : IRequestHandler<GetTenantsQuery, ErrorOr<List<TenantDto>>>
+{
+    public async Task<ErrorOr<List<TenantDto>>> Handle(GetTenantsQuery request, CancellationToken ct)
+    {
+        var tenants = await db.Tenants
+            .AsNoTracking()
+            .OrderBy(t => t.Name)
+            .Select(t => new TenantDto(t.Id, t.Name, t.ContactEmail, t.Plan, t.IsActive, t.CreatedAt))
+            .ToListAsync(ct);
+
+        return tenants;
+    }
+}

--- a/src/SmartEstate.Web/Layout/NavMenu.razor
+++ b/src/SmartEstate.Web/Layout/NavMenu.razor
@@ -24,4 +24,16 @@
     <MudNavLink Href="/notifications" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.NotificationsNone">
         Notifications
     </MudNavLink>
+
+    <AuthorizeView Roles="Administrator">
+        <Authorized>
+            <MudDivider Class="my-2" />
+
+            <MudNavGroup Title="Administration" Icon="@Icons.Material.Filled.AdminPanelSettings" Expanded="true">
+                <MudNavLink Href="/admin/tenants" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Business">
+                    Tenants
+                </MudNavLink>
+            </MudNavGroup>
+        </Authorized>
+    </AuthorizeView>
 </MudNavMenu>

--- a/src/SmartEstate.Web/Models/Admin/TenantDto.cs
+++ b/src/SmartEstate.Web/Models/Admin/TenantDto.cs
@@ -1,0 +1,11 @@
+namespace SmartEstate.Web.Models.Admin;
+
+public class TenantDto
+{
+    public Guid Id { get; init; }
+    public string Name { get; init; } = string.Empty;
+    public string ContactEmail { get; init; } = string.Empty;
+    public string? Plan { get; init; }
+    public bool IsActive { get; set; }
+    public DateTime CreatedAt { get; init; }
+}

--- a/src/SmartEstate.Web/Pages/Admin/Tenants.razor
+++ b/src/SmartEstate.Web/Pages/Admin/Tenants.razor
@@ -1,0 +1,213 @@
+@page "/admin/tenants"
+@attribute [Authorize(Roles = "Administrator")]
+@inject TenantAdminService TenantService
+@inject ISnackbar Snackbar
+@using SmartEstate.Web.Models.Admin
+
+<PageTitle>Tenants — SmartEstate Admin</PageTitle>
+
+<MudContainer MaxWidth="MaxWidth.Large">
+    <MudStack Row="true" AlignItems="AlignItems.Center" Class="mb-4">
+        <MudText Typo="Typo.h5">Tenants</MudText>
+        <MudSpacer />
+        <MudButton Variant="Variant.Filled"
+                   Color="Color.Primary"
+                   StartIcon="@Icons.Material.Filled.Add"
+                   OnClick="OpenCreateDialog">
+            Create Tenant
+        </MudButton>
+    </MudStack>
+
+    @if (_isLoading)
+    {
+        <MudProgressLinear Indeterminate="true" />
+    }
+    else if (_error is not null)
+    {
+        <MudAlert Severity="Severity.Error">@_error</MudAlert>
+    }
+    else
+    {
+        <MudDataGrid T="TenantDto"
+                     Items="_tenants"
+                     Filterable="false"
+                     SortMode="SortMode.Single"
+                     Hover="true"
+                     Striped="true"
+                     Elevation="2">
+            <Columns>
+                <PropertyColumn Property="t => t.Name" Title="Name" />
+                <PropertyColumn Property="t => t.ContactEmail" Title="Contact Email" />
+                <PropertyColumn Property="t => t.Plan" Title="Plan" />
+                <TemplateColumn Title="Status" SortBy="t => t.IsActive">
+                    <CellTemplate>
+                        @if (context.Item.IsActive)
+                        {
+                            <MudChip T="string" Color="Color.Success" Size="Size.Small" Variant="Variant.Filled">Active</MudChip>
+                        }
+                        else
+                        {
+                            <MudChip T="string" Color="Color.Default" Size="Size.Small" Variant="Variant.Filled">Inactive</MudChip>
+                        }
+                    </CellTemplate>
+                </TemplateColumn>
+                <PropertyColumn Property="t => t.CreatedAt" Title="Created At" Format="yyyy-MM-dd" />
+                <TemplateColumn Title="Actions" Sortable="false">
+                    <CellTemplate>
+                        <MudTooltip Text="@(context.Item.IsActive ? "Deactivate" : "Activate")">
+                            <MudIconButton Icon="@(context.Item.IsActive ? Icons.Material.Filled.ToggleOn : Icons.Material.Filled.ToggleOff)"
+                                           Color="@(context.Item.IsActive ? Color.Success : Color.Default)"
+                                           Size="Size.Small"
+                                           OnClick="() => ToggleActive(context.Item)" />
+                        </MudTooltip>
+                    </CellTemplate>
+                </TemplateColumn>
+            </Columns>
+        </MudDataGrid>
+    }
+</MudContainer>
+
+<MudDialog @bind-Visible="_createDialogOpen" Options="_dialogOptions">
+    <TitleContent>
+        <MudText Typo="Typo.h6">Create Tenant</MudText>
+    </TitleContent>
+    <DialogContent>
+        <MudForm @ref="_createForm" @bind-IsValid="_isCreateFormValid">
+            <MudGrid>
+                <MudItem xs="12">
+                    <MudTextField T="string"
+                                  @bind-Value="_newName"
+                                  Label="Agency Name"
+                                  Required="true"
+                                  RequiredError="Name is required." />
+                </MudItem>
+                <MudItem xs="12">
+                    <MudTextField T="string"
+                                  @bind-Value="_newEmail"
+                                  Label="Contact Email"
+                                  InputType="InputType.Email"
+                                  Required="true"
+                                  RequiredError="Contact email is required."
+                                  Validation="@(new EmailAddressAttribute())" />
+                </MudItem>
+                <MudItem xs="12">
+                    <MudTextField T="string"
+                                  @bind-Value="_newPlan"
+                                  Label="Plan"
+                                  Required="true"
+                                  RequiredError="Plan is required." />
+                </MudItem>
+            </MudGrid>
+        </MudForm>
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="CloseCreateDialog">Cancel</MudButton>
+        <MudButton Variant="Variant.Filled"
+                   Color="Color.Primary"
+                   Disabled="_isCreating"
+                   OnClick="SubmitCreate">
+            @if (_isCreating)
+            {
+                <MudProgressCircular Size="Size.Small" Indeterminate="true" Class="mr-2" />
+                <span>Creating...</span>
+            }
+            else
+            {
+                <span>Create</span>
+            }
+        </MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    private List<TenantDto> _tenants = [];
+    private bool _isLoading = true;
+    private string? _error;
+
+    private bool _createDialogOpen;
+    private MudForm _createForm = null!;
+    private bool _isCreateFormValid;
+    private bool _isCreating;
+    private string _newName = string.Empty;
+    private string _newEmail = string.Empty;
+    private string _newPlan = string.Empty;
+
+    private readonly DialogOptions _dialogOptions = new()
+    {
+        MaxWidth = MaxWidth.Small,
+        FullWidth = true,
+        CloseOnEscapeKey = true
+    };
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadTenants();
+    }
+
+    private async Task LoadTenants()
+    {
+        _isLoading = true;
+        _error = null;
+
+        var result = await TenantService.GetAllAsync();
+        if (result is not null)
+            _tenants = result;
+        else
+            _error = "Failed to load tenants. Please try again.";
+
+        _isLoading = false;
+    }
+
+    private void OpenCreateDialog()
+    {
+        _newName = string.Empty;
+        _newEmail = string.Empty;
+        _newPlan = string.Empty;
+        _createDialogOpen = true;
+    }
+
+    private void CloseCreateDialog() => _createDialogOpen = false;
+
+    private async Task SubmitCreate()
+    {
+        await _createForm.ValidateAsync();
+        if (!_isCreateFormValid) return;
+
+        _isCreating = true;
+        var (tenant, error) = await TenantService.CreateAsync(_newName, _newEmail, _newPlan);
+        _isCreating = false;
+
+        if (tenant is not null)
+        {
+            _tenants.Add(tenant);
+            _tenants = [.. _tenants.OrderBy(t => t.Name)];
+            CloseCreateDialog();
+            Snackbar.Add($"Tenant '{tenant.Name}' created successfully.", Severity.Success);
+        }
+        else
+        {
+            Snackbar.Add(error ?? "Failed to create tenant.", Severity.Error);
+        }
+    }
+
+    private async Task ToggleActive(TenantDto tenant)
+    {
+        var previousState = tenant.IsActive;
+        tenant.IsActive = !tenant.IsActive;
+
+        var (updated, error) = await TenantService.SetActiveAsync(tenant.Id, tenant.IsActive);
+
+        if (updated is not null)
+        {
+            tenant.IsActive = updated.IsActive;
+            Snackbar.Add(
+                $"Tenant '{tenant.Name}' {(tenant.IsActive ? "activated" : "deactivated")}.",
+                Severity.Success);
+        }
+        else
+        {
+            tenant.IsActive = previousState;
+            Snackbar.Add(error ?? "Failed to update tenant status.", Severity.Error);
+        }
+    }
+}

--- a/src/SmartEstate.Web/Program.cs
+++ b/src/SmartEstate.Web/Program.cs
@@ -26,5 +26,6 @@ builder.Services.AddScoped<AuthenticationStateProvider>(
 
 builder.Services.AddScoped<ApiClient>();
 builder.Services.AddScoped<AuthService>();
+builder.Services.AddScoped<TenantAdminService>();
 
 await builder.Build().RunAsync();

--- a/src/SmartEstate.Web/Services/TenantAdminService.cs
+++ b/src/SmartEstate.Web/Services/TenantAdminService.cs
@@ -1,0 +1,35 @@
+using SmartEstate.Web.Models.Admin;
+using SmartEstate.Web.Models.Common;
+
+namespace SmartEstate.Web.Services;
+
+public class TenantAdminService(ApiClient api)
+{
+    public async Task<List<TenantDto>?> GetAllAsync()
+    {
+        var response = await api.GetAsync<List<TenantDto>>("api/admin/tenants");
+        return response?.Success == true ? response.Data : null;
+    }
+
+    public async Task<(TenantDto? tenant, string? error)> CreateAsync(string name, string contactEmail, string plan)
+    {
+        var response = await api.PostAsync<TenantDto>("api/admin/tenants",
+            new { name, contactEmail, plan });
+
+        if (response?.Success == true && response.Data is not null)
+            return (response.Data, null);
+
+        return (null, response?.Message ?? "Failed to create tenant.");
+    }
+
+    public async Task<(TenantDto? tenant, string? error)> SetActiveAsync(Guid id, bool isActive)
+    {
+        var response = await api.PatchAsync<TenantDto>($"api/admin/tenants/{id}/activate",
+            new { isActive });
+
+        if (response?.Success == true && response.Data is not null)
+            return (response.Data, null);
+
+        return (null, response?.Message ?? "Failed to update tenant status.");
+    }
+}


### PR DESCRIPTION
Closes #33

Implemented:
- Admin tenants page at /admin/tenants with MudDataGrid, loading and error states.
- Create tenant dialog with required fields and email validation.
- Activate/deactivate tenant action with optimistic local state update and snackbar feedback.
- TenantAdminService and client TenantDto for admin tenant API calls.
- Administrator-only Administration -> Tenants nav entry.
- GET /api/admin/tenants backend query used by the grid.
- Updated project frontend notes and Sprint 1 task statuses.

Verification:
- dotnet build SmartEstate.slnx