### PR TITLE
[Backend] Buyer schema + API contract foundation

### DIFF
--- a/src/SmartEstate.Application/Common/Models/PagedResult.cs
+++ b/src/SmartEstate.Application/Common/Models/PagedResult.cs
@@ -1,0 +1,12 @@
+namespace SmartEstate.Application.Common.Models;
+
+public class PagedResult<T>
+{
+    public List<T> Items { get; init; } = [];
+    public int TotalCount { get; init; }
+    public int PageNumber { get; init; }
+    public int PageSize { get; init; }
+    public int TotalPages => (int)Math.Ceiling((double)TotalCount / PageSize);
+    public bool HasNextPage => PageNumber < TotalPages;
+    public bool HasPreviousPage => PageNumber > 1;
+}

--- a/src/SmartEstate.Application/Features/Buyers/DTOs/BuyerDto.cs
+++ b/src/SmartEstate.Application/Features/Buyers/DTOs/BuyerDto.cs
@@ -1,0 +1,17 @@
+namespace SmartEstate.Application.Features.Buyers.DTOs;
+
+public class BuyerDto
+{
+    public Guid Id { get; init; }
+    public Guid TenantId { get; init; }
+    public Guid AssignedAgentId { get; init; }
+    public string FullName { get; init; } = string.Empty;
+    public string? Email { get; init; }
+    public string? Phone { get; init; }
+    public string LifestyleDescription { get; init; } = string.Empty;
+    public decimal? BudgetMinEur { get; init; }
+    public decimal? BudgetMaxEur { get; init; }
+    public List<string> PreferredLocations { get; init; } = [];
+    public DateTime CreatedAt { get; init; }
+    public DateTime? UpdatedAt { get; init; }
+}

--- a/src/SmartEstate.Application/Features/Buyers/DTOs/BuyerDto.cs
+++ b/src/SmartEstate.Application/Features/Buyers/DTOs/BuyerDto.cs
@@ -3,7 +3,6 @@ namespace SmartEstate.Application.Features.Buyers.DTOs;
 public class BuyerDto
 {
     public Guid Id { get; init; }
-    public Guid TenantId { get; init; }
     public Guid AssignedAgentId { get; init; }
     public string FullName { get; init; } = string.Empty;
     public string? Email { get; init; }

--- a/src/SmartEstate.Application/Features/Buyers/DTOs/BuyerListItemDto.cs
+++ b/src/SmartEstate.Application/Features/Buyers/DTOs/BuyerListItemDto.cs
@@ -1,0 +1,13 @@
+namespace SmartEstate.Application.Features.Buyers.DTOs;
+
+public class BuyerListItemDto
+{
+    public Guid Id { get; init; }
+    public string FullName { get; init; } = string.Empty;
+    public string? Email { get; init; }
+    public string? Phone { get; init; }
+    public decimal? BudgetMinEur { get; init; }
+    public decimal? BudgetMaxEur { get; init; }
+    public List<string> PreferredLocations { get; init; } = [];
+    public DateTime CreatedAt { get; init; }
+}

--- a/src/SmartEstate.Domain/Common/ISoftDeletable.cs
+++ b/src/SmartEstate.Domain/Common/ISoftDeletable.cs
@@ -1,0 +1,6 @@
+namespace SmartEstate.Domain.Common;
+
+public interface ISoftDeletable
+{
+    bool IsDeleted { get; set; }
+}

--- a/src/SmartEstate.Domain/Entities/Buyer.cs
+++ b/src/SmartEstate.Domain/Entities/Buyer.cs
@@ -2,13 +2,17 @@ using SmartEstate.Domain.Common;
 
 namespace SmartEstate.Domain.Entities;
 
-public class Buyer : BaseEntity, ITenantEntity
+public class Buyer : BaseEntity, ITenantEntity, ISoftDeletable
 {
     public Guid TenantId { get; set; }
     public string FullName { get; set; } = string.Empty;
     public string? Email { get; set; }
     public string? Phone { get; set; }
     public string LifestyleDescription { get; set; } = string.Empty;
+    public decimal? BudgetMinEur { get; set; }
+    public decimal? BudgetMaxEur { get; set; }
+    public List<string> PreferredLocations { get; set; } = [];
+    public bool IsDeleted { get; set; } = false;
     public List<string> AiTags { get; set; } = [];
     public string? AiProfile { get; set; }
     public DateTime? LastAiProcessedAt { get; set; }

--- a/src/SmartEstate.Infrastructure/Persistence/AppDbContext.cs
+++ b/src/SmartEstate.Infrastructure/Persistence/AppDbContext.cs
@@ -24,7 +24,9 @@ public class AppDbContext(DbContextOptions<AppDbContext> options, ITenantContext
 
         // tenantContext is a primary-constructor-captured field, re-evaluated per query.
         // When TenantId is null (Administrator or no HTTP context) the filter is bypassed.
-        ApplyTenantFilter<Buyer>(builder);
+        builder.Entity<Buyer>().HasQueryFilter(e =>
+            (!tenantContext.TenantId.HasValue || e.TenantId == tenantContext.TenantId.Value)
+            && !e.IsDeleted);
         ApplyTenantFilter<Property>(builder);
         ApplyTenantFilter<MatchReport>(builder);
         ApplyTenantFilter<InAppNotification>(builder);

--- a/src/SmartEstate.Infrastructure/Persistence/Migrations/20260423223436_AddBuyerFields.Designer.cs
+++ b/src/SmartEstate.Infrastructure/Persistence/Migrations/20260423223436_AddBuyerFields.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SmartEstate.Infrastructure.Persistence;
@@ -12,9 +13,11 @@ using SmartEstate.Infrastructure.Persistence;
 namespace SmartEstate.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260423223436_AddBuyerFields")]
+    partial class AddBuyerFields
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/SmartEstate.Infrastructure/Persistence/Migrations/20260423223436_AddBuyerFields.cs
+++ b/src/SmartEstate.Infrastructure/Persistence/Migrations/20260423223436_AddBuyerFields.cs
@@ -34,7 +34,8 @@ namespace SmartEstate.Infrastructure.Persistence.Migrations
                 name: "PreferredLocations",
                 table: "Buyers",
                 type: "text[]",
-                nullable: false);
+                nullable: false,
+                defaultValueSql: "ARRAY[]::text[]");
 
             migrationBuilder.CreateIndex(
                 name: "IX_Buyers_TenantId_IsDeleted_FullName",

--- a/src/SmartEstate.Infrastructure/Persistence/Migrations/20260423223436_AddBuyerFields.cs
+++ b/src/SmartEstate.Infrastructure/Persistence/Migrations/20260423223436_AddBuyerFields.cs
@@ -1,0 +1,69 @@
+﻿using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SmartEstate.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddBuyerFields : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<decimal>(
+                name: "BudgetMaxEur",
+                table: "Buyers",
+                type: "numeric",
+                nullable: true);
+
+            migrationBuilder.AddColumn<decimal>(
+                name: "BudgetMinEur",
+                table: "Buyers",
+                type: "numeric",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsDeleted",
+                table: "Buyers",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<List<string>>(
+                name: "PreferredLocations",
+                table: "Buyers",
+                type: "text[]",
+                nullable: false);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Buyers_TenantId_IsDeleted_FullName",
+                table: "Buyers",
+                columns: new[] { "TenantId", "IsDeleted", "FullName" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Buyers_TenantId_IsDeleted_FullName",
+                table: "Buyers");
+
+            migrationBuilder.DropColumn(
+                name: "BudgetMaxEur",
+                table: "Buyers");
+
+            migrationBuilder.DropColumn(
+                name: "BudgetMinEur",
+                table: "Buyers");
+
+            migrationBuilder.DropColumn(
+                name: "IsDeleted",
+                table: "Buyers");
+
+            migrationBuilder.DropColumn(
+                name: "PreferredLocations",
+                table: "Buyers");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `BudgetMinEur`, `BudgetMaxEur`, `PreferredLocations`, `IsDeleted` fields to `Buyer` entity
- Introduces `ISoftDeletable` interface in `SmartEstate.Domain/Common/`
- Updates `AppDbContext`: `Buyer` global query filter now combines tenant isolation + soft-delete exclusion in a single `HasQueryFilter` call (EF Core allows only one per entity)
- EF Core migration `AddBuyerFields` — existing rows remain valid (nullables, `IsDeleted = false` default, empty array)
- Composite index `IX_Buyers_TenantId_IsDeleted_FullName` for efficient paginated queries
- `BuyerDto` and `BuyerListItemDto` in `Application/Features/Buyers/DTOs/`
- `PagedResult<T>` in `Application/Common/Models/`

## Migration instructions

```
dotnet ef database update --project src/SmartEstate.Infrastructure --startup-project src/SmartEstate.API
```

## Notes

- AI fields (`AiTags`, `AiProfile`, `LastAiProcessedAt`) untouched — reserved for Sprint 4
- `Property` entity will get soft-delete + `ISoftDeletable` in Sprint 3

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)