### PR TITLE
[Backend] POST /api/buyers + GET /api/buyers paginated list

### DIFF
--- a/src/SmartEstate.API/Controllers/BuyersController.cs
+++ b/src/SmartEstate.API/Controllers/BuyersController.cs
@@ -1,0 +1,69 @@
+using ErrorOr;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using SmartEstate.API.Models.Requests;
+using SmartEstate.Application.Common.Models;
+using SmartEstate.Application.Features.Buyers.Commands.CreateBuyer;
+using SmartEstate.Application.Features.Buyers.DTOs;
+using SmartEstate.Application.Features.Buyers.Queries.GetBuyers;
+using SmartEstate.Infrastructure.Identity;
+using System.Security.Claims;
+
+namespace SmartEstate.API.Controllers;
+
+[ApiController]
+[Route("api/buyers")]
+[Authorize(Roles = $"{AppRoles.Agent},{AppRoles.AgencyManager}")]
+public class BuyersController(ISender mediator) : ControllerBase
+{
+    [HttpPost]
+    public async Task<IActionResult> Create([FromBody] CreateBuyerRequest body, CancellationToken ct)
+    {
+        var agentId = Guid.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier)!);
+        var command = new CreateBuyerCommand(
+            agentId,
+            body.FullName,
+            body.LifestyleDescription,
+            body.Email,
+            body.Phone,
+            body.BudgetMinEur,
+            body.BudgetMaxEur,
+            body.PreferredLocations);
+
+        var result = await mediator.Send(command, ct);
+        return result.Match(
+            dto => CreatedAtAction(nameof(GetById), new { id = dto.Id }, ApiResponse<BuyerDto>.Ok(dto)),
+            errors => MapErrors(errors));
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> GetAll(
+        [FromQuery] int pageNumber = 1,
+        [FromQuery] int pageSize = 20,
+        [FromQuery] string? search = null,
+        CancellationToken ct = default)
+    {
+        var result = await mediator.Send(new GetBuyersQuery(pageNumber, pageSize, search), ct);
+        return result.Match(
+            paged => Ok(ApiResponse<PagedResult<BuyerListItemDto>>.Ok(paged)),
+            errors => MapErrors(errors));
+    }
+
+    [HttpGet("{id:guid}")]
+    public IActionResult GetById(Guid id) => NotFound();
+
+    private IActionResult MapErrors(List<Error> errors)
+    {
+        if (errors.Any(e => e.Type == ErrorType.NotFound))
+            return NotFound(ApiResponse.Fail(errors.First(e => e.Type == ErrorType.NotFound).Description));
+        if (errors.Any(e => e.Type == ErrorType.Conflict))
+            return Conflict(ApiResponse.Fail(errors.First(e => e.Type == ErrorType.Conflict).Description));
+        if (errors.Any(e => e.Type == ErrorType.Validation))
+        {
+            var messages = errors.Where(e => e.Type == ErrorType.Validation).Select(e => e.Description).ToList();
+            return BadRequest(ApiResponse.Fail("Validation failed.", messages));
+        }
+        return StatusCode(StatusCodes.Status500InternalServerError, ApiResponse.Fail("An unexpected error occurred."));
+    }
+}

--- a/src/SmartEstate.API/Models/Requests/CreateBuyerRequest.cs
+++ b/src/SmartEstate.API/Models/Requests/CreateBuyerRequest.cs
@@ -1,0 +1,10 @@
+namespace SmartEstate.API.Models.Requests;
+
+public record CreateBuyerRequest(
+    string FullName,
+    string LifestyleDescription,
+    string? Email,
+    string? Phone,
+    decimal? BudgetMinEur,
+    decimal? BudgetMaxEur,
+    List<string>? PreferredLocations);

--- a/src/SmartEstate.Application/Features/Buyers/Commands/CreateBuyer/CreateBuyerCommand.cs
+++ b/src/SmartEstate.Application/Features/Buyers/Commands/CreateBuyer/CreateBuyerCommand.cs
@@ -1,0 +1,15 @@
+using ErrorOr;
+using MediatR;
+using SmartEstate.Application.Features.Buyers.DTOs;
+
+namespace SmartEstate.Application.Features.Buyers.Commands.CreateBuyer;
+
+public record CreateBuyerCommand(
+    Guid AssignedAgentId,
+    string FullName,
+    string LifestyleDescription,
+    string? Email,
+    string? Phone,
+    decimal? BudgetMinEur,
+    decimal? BudgetMaxEur,
+    List<string>? PreferredLocations) : IRequest<ErrorOr<BuyerDto>>;

--- a/src/SmartEstate.Application/Features/Buyers/Commands/CreateBuyer/CreateBuyerCommandHandler.cs
+++ b/src/SmartEstate.Application/Features/Buyers/Commands/CreateBuyer/CreateBuyerCommandHandler.cs
@@ -1,0 +1,47 @@
+using ErrorOr;
+using MediatR;
+using SmartEstate.Application.Common.Interfaces;
+using SmartEstate.Application.Features.Buyers.DTOs;
+using SmartEstate.Domain.Entities;
+
+namespace SmartEstate.Application.Features.Buyers.Commands.CreateBuyer;
+
+public class CreateBuyerCommandHandler(IApplicationDbContext db, ITenantContext tenantContext)
+    : IRequestHandler<CreateBuyerCommand, ErrorOr<BuyerDto>>
+{
+    public async Task<ErrorOr<BuyerDto>> Handle(CreateBuyerCommand request, CancellationToken cancellationToken)
+    {
+        var buyer = new Buyer
+        {
+            TenantId = tenantContext.TenantId!.Value,
+            AssignedAgentId = request.AssignedAgentId,
+            FullName = request.FullName,
+            LifestyleDescription = request.LifestyleDescription,
+            Email = request.Email,
+            Phone = request.Phone,
+            BudgetMinEur = request.BudgetMinEur,
+            BudgetMaxEur = request.BudgetMaxEur,
+            PreferredLocations = request.PreferredLocations ?? []
+        };
+
+        db.Buyers.Add(buyer);
+        await db.SaveChangesAsync(cancellationToken);
+
+        return MapToDto(buyer);
+    }
+
+    private static BuyerDto MapToDto(Buyer buyer) => new()
+    {
+        Id = buyer.Id,
+        AssignedAgentId = buyer.AssignedAgentId,
+        FullName = buyer.FullName,
+        Email = buyer.Email,
+        Phone = buyer.Phone,
+        LifestyleDescription = buyer.LifestyleDescription,
+        BudgetMinEur = buyer.BudgetMinEur,
+        BudgetMaxEur = buyer.BudgetMaxEur,
+        PreferredLocations = buyer.PreferredLocations,
+        CreatedAt = buyer.CreatedAt,
+        UpdatedAt = buyer.UpdatedAt
+    };
+}

--- a/src/SmartEstate.Application/Features/Buyers/Commands/CreateBuyer/CreateBuyerCommandValidator.cs
+++ b/src/SmartEstate.Application/Features/Buyers/Commands/CreateBuyer/CreateBuyerCommandValidator.cs
@@ -1,0 +1,38 @@
+using FluentValidation;
+
+namespace SmartEstate.Application.Features.Buyers.Commands.CreateBuyer;
+
+public class CreateBuyerCommandValidator : AbstractValidator<CreateBuyerCommand>
+{
+    public CreateBuyerCommandValidator()
+    {
+        RuleFor(x => x.FullName)
+            .NotEmpty()
+            .MaximumLength(200);
+
+        RuleFor(x => x.LifestyleDescription)
+            .NotEmpty()
+            .MaximumLength(4000);
+
+        RuleFor(x => x.Email)
+            .EmailAddress()
+            .When(x => x.Email is not null);
+
+        RuleFor(x => x.Phone)
+            .MaximumLength(50)
+            .When(x => x.Phone is not null);
+
+        RuleFor(x => x.BudgetMinEur)
+            .GreaterThanOrEqualTo(0)
+            .When(x => x.BudgetMinEur is not null);
+
+        RuleFor(x => x.BudgetMaxEur)
+            .GreaterThanOrEqualTo(0)
+            .When(x => x.BudgetMaxEur is not null);
+
+        RuleFor(x => x)
+            .Must(x => x.BudgetMinEur <= x.BudgetMaxEur)
+            .When(x => x.BudgetMinEur is not null && x.BudgetMaxEur is not null)
+            .WithMessage("BudgetMinEur must be less than or equal to BudgetMaxEur.");
+    }
+}

--- a/src/SmartEstate.Application/Features/Buyers/Queries/GetBuyers/GetBuyersQuery.cs
+++ b/src/SmartEstate.Application/Features/Buyers/Queries/GetBuyers/GetBuyersQuery.cs
@@ -1,0 +1,11 @@
+using ErrorOr;
+using MediatR;
+using SmartEstate.Application.Common.Models;
+using SmartEstate.Application.Features.Buyers.DTOs;
+
+namespace SmartEstate.Application.Features.Buyers.Queries.GetBuyers;
+
+public record GetBuyersQuery(
+    int PageNumber,
+    int PageSize,
+    string? Search) : IRequest<ErrorOr<PagedResult<BuyerListItemDto>>>;

--- a/src/SmartEstate.Application/Features/Buyers/Queries/GetBuyers/GetBuyersQueryHandler.cs
+++ b/src/SmartEstate.Application/Features/Buyers/Queries/GetBuyers/GetBuyersQueryHandler.cs
@@ -1,0 +1,55 @@
+using ErrorOr;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using SmartEstate.Application.Common.Interfaces;
+using SmartEstate.Application.Common.Models;
+using SmartEstate.Application.Features.Buyers.DTOs;
+
+namespace SmartEstate.Application.Features.Buyers.Queries.GetBuyers;
+
+public class GetBuyersQueryHandler(IApplicationDbContext db)
+    : IRequestHandler<GetBuyersQuery, ErrorOr<PagedResult<BuyerListItemDto>>>
+{
+    public async Task<ErrorOr<PagedResult<BuyerListItemDto>>> Handle(
+        GetBuyersQuery request, CancellationToken cancellationToken)
+    {
+        var query = db.Buyers.AsNoTracking();
+
+        if (!string.IsNullOrWhiteSpace(request.Search))
+        {
+            var search = request.Search.ToLower();
+            query = query.Where(b =>
+                b.FullName.ToLower().Contains(search) ||
+                (b.Email != null && b.Email.ToLower().Contains(search)) ||
+                (b.Phone != null && b.Phone.ToLower().Contains(search)) ||
+                b.PreferredLocations.Any(l => l.ToLower().Contains(search)));
+        }
+
+        var totalCount = await query.CountAsync(cancellationToken);
+
+        var items = await query
+            .OrderByDescending(b => b.CreatedAt)
+            .Skip((request.PageNumber - 1) * request.PageSize)
+            .Take(request.PageSize)
+            .Select(b => new BuyerListItemDto
+            {
+                Id = b.Id,
+                FullName = b.FullName,
+                Email = b.Email,
+                Phone = b.Phone,
+                BudgetMinEur = b.BudgetMinEur,
+                BudgetMaxEur = b.BudgetMaxEur,
+                PreferredLocations = b.PreferredLocations,
+                CreatedAt = b.CreatedAt
+            })
+            .ToListAsync(cancellationToken);
+
+        return new PagedResult<BuyerListItemDto>
+        {
+            Items = items,
+            TotalCount = totalCount,
+            PageNumber = request.PageNumber,
+            PageSize = request.PageSize
+        };
+    }
+}


### PR DESCRIPTION
## Summary

- `CreateBuyerCommand` + handler + FluentValidation validator (fullName max 200, lifestyleDescription max 4000, email format, phone max 50, budgets non-negative, min ≤ max)
- `GetBuyersQuery` + handler — server-side pagination + search across fullName, email, phone, preferredLocations
- `BuyersController` — `POST /api/buyers` (201 Created) and `GET /api/buyers?pageNumber&pageSize&search` (200 OK)
- `AssignedAgentId` extracted from JWT `sub` claim in controller — never from client input
- Roles: `Agent`, `AgencyManager`
- `GetById` stub added to satisfy `CreatedAtAction` reference — will be replaced in #47

Closes #46