### PR TITLE
[Backend] GET /api/buyers/{id} + PUT /api/buyers/{id}

### DIFF
--- a/src/SmartEstate.API/Controllers/BuyersController.cs
+++ b/src/SmartEstate.API/Controllers/BuyersController.cs
@@ -5,7 +5,9 @@ using Microsoft.AspNetCore.Mvc;
 using SmartEstate.API.Models.Requests;
 using SmartEstate.Application.Common.Models;
 using SmartEstate.Application.Features.Buyers.Commands.CreateBuyer;
+using SmartEstate.Application.Features.Buyers.Commands.UpdateBuyer;
 using SmartEstate.Application.Features.Buyers.DTOs;
+using SmartEstate.Application.Features.Buyers.Queries.GetBuyer;
 using SmartEstate.Application.Features.Buyers.Queries.GetBuyers;
 using SmartEstate.Infrastructure.Identity;
 using System.Security.Claims;
@@ -51,7 +53,32 @@ public class BuyersController(ISender mediator) : ControllerBase
     }
 
     [HttpGet("{id:guid}")]
-    public IActionResult GetById(Guid id) => NotFound();
+    public async Task<IActionResult> GetById(Guid id, CancellationToken ct)
+    {
+        var result = await mediator.Send(new GetBuyerQuery(id), ct);
+        return result.Match(
+            dto => Ok(ApiResponse<BuyerDto>.Ok(dto)),
+            errors => MapErrors(errors));
+    }
+
+    [HttpPut("{id:guid}")]
+    public async Task<IActionResult> Update(Guid id, [FromBody] UpdateBuyerRequest body, CancellationToken ct)
+    {
+        var command = new UpdateBuyerCommand(
+            id,
+            body.FullName,
+            body.LifestyleDescription,
+            body.Email,
+            body.Phone,
+            body.BudgetMinEur,
+            body.BudgetMaxEur,
+            body.PreferredLocations);
+
+        var result = await mediator.Send(command, ct);
+        return result.Match(
+            dto => Ok(ApiResponse<BuyerDto>.Ok(dto)),
+            errors => MapErrors(errors));
+    }
 
     private IActionResult MapErrors(List<Error> errors)
     {

--- a/src/SmartEstate.API/Models/Requests/UpdateBuyerRequest.cs
+++ b/src/SmartEstate.API/Models/Requests/UpdateBuyerRequest.cs
@@ -1,0 +1,10 @@
+namespace SmartEstate.API.Models.Requests;
+
+public record UpdateBuyerRequest(
+    string FullName,
+    string LifestyleDescription,
+    string? Email,
+    string? Phone,
+    decimal? BudgetMinEur,
+    decimal? BudgetMaxEur,
+    List<string>? PreferredLocations);

--- a/src/SmartEstate.Application/Features/Buyers/Commands/UpdateBuyer/UpdateBuyerCommand.cs
+++ b/src/SmartEstate.Application/Features/Buyers/Commands/UpdateBuyer/UpdateBuyerCommand.cs
@@ -1,0 +1,15 @@
+using ErrorOr;
+using MediatR;
+using SmartEstate.Application.Features.Buyers.DTOs;
+
+namespace SmartEstate.Application.Features.Buyers.Commands.UpdateBuyer;
+
+public record UpdateBuyerCommand(
+    Guid Id,
+    string FullName,
+    string LifestyleDescription,
+    string? Email,
+    string? Phone,
+    decimal? BudgetMinEur,
+    decimal? BudgetMaxEur,
+    List<string>? PreferredLocations) : IRequest<ErrorOr<BuyerDto>>;

--- a/src/SmartEstate.Application/Features/Buyers/Commands/UpdateBuyer/UpdateBuyerCommandHandler.cs
+++ b/src/SmartEstate.Application/Features/Buyers/Commands/UpdateBuyer/UpdateBuyerCommandHandler.cs
@@ -1,0 +1,46 @@
+using ErrorOr;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using SmartEstate.Application.Common.Interfaces;
+using SmartEstate.Application.Features.Buyers.DTOs;
+
+namespace SmartEstate.Application.Features.Buyers.Commands.UpdateBuyer;
+
+public class UpdateBuyerCommandHandler(IApplicationDbContext db)
+    : IRequestHandler<UpdateBuyerCommand, ErrorOr<BuyerDto>>
+{
+    public async Task<ErrorOr<BuyerDto>> Handle(UpdateBuyerCommand request, CancellationToken cancellationToken)
+    {
+        var buyer = await db.Buyers
+            .Where(b => b.Id == request.Id)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (buyer is null)
+            return Error.NotFound(description: "Buyer not found.");
+
+        buyer.FullName = request.FullName;
+        buyer.LifestyleDescription = request.LifestyleDescription;
+        buyer.Email = request.Email;
+        buyer.Phone = request.Phone;
+        buyer.BudgetMinEur = request.BudgetMinEur;
+        buyer.BudgetMaxEur = request.BudgetMaxEur;
+        buyer.PreferredLocations = request.PreferredLocations ?? [];
+
+        await db.SaveChangesAsync(cancellationToken);
+
+        return new BuyerDto
+        {
+            Id = buyer.Id,
+            AssignedAgentId = buyer.AssignedAgentId,
+            FullName = buyer.FullName,
+            Email = buyer.Email,
+            Phone = buyer.Phone,
+            LifestyleDescription = buyer.LifestyleDescription,
+            BudgetMinEur = buyer.BudgetMinEur,
+            BudgetMaxEur = buyer.BudgetMaxEur,
+            PreferredLocations = buyer.PreferredLocations,
+            CreatedAt = buyer.CreatedAt,
+            UpdatedAt = buyer.UpdatedAt
+        };
+    }
+}

--- a/src/SmartEstate.Application/Features/Buyers/Commands/UpdateBuyer/UpdateBuyerCommandValidator.cs
+++ b/src/SmartEstate.Application/Features/Buyers/Commands/UpdateBuyer/UpdateBuyerCommandValidator.cs
@@ -1,0 +1,38 @@
+using FluentValidation;
+
+namespace SmartEstate.Application.Features.Buyers.Commands.UpdateBuyer;
+
+public class UpdateBuyerCommandValidator : AbstractValidator<UpdateBuyerCommand>
+{
+    public UpdateBuyerCommandValidator()
+    {
+        RuleFor(x => x.FullName)
+            .NotEmpty()
+            .MaximumLength(200);
+
+        RuleFor(x => x.LifestyleDescription)
+            .NotEmpty()
+            .MaximumLength(4000);
+
+        RuleFor(x => x.Email)
+            .EmailAddress()
+            .When(x => x.Email is not null);
+
+        RuleFor(x => x.Phone)
+            .MaximumLength(50)
+            .When(x => x.Phone is not null);
+
+        RuleFor(x => x.BudgetMinEur)
+            .GreaterThanOrEqualTo(0)
+            .When(x => x.BudgetMinEur is not null);
+
+        RuleFor(x => x.BudgetMaxEur)
+            .GreaterThanOrEqualTo(0)
+            .When(x => x.BudgetMaxEur is not null);
+
+        RuleFor(x => x)
+            .Must(x => x.BudgetMinEur <= x.BudgetMaxEur)
+            .When(x => x.BudgetMinEur is not null && x.BudgetMaxEur is not null)
+            .WithMessage("BudgetMinEur must be less than or equal to BudgetMaxEur.");
+    }
+}

--- a/src/SmartEstate.Application/Features/Buyers/Queries/GetBuyer/GetBuyerQuery.cs
+++ b/src/SmartEstate.Application/Features/Buyers/Queries/GetBuyer/GetBuyerQuery.cs
@@ -1,0 +1,7 @@
+using ErrorOr;
+using MediatR;
+using SmartEstate.Application.Features.Buyers.DTOs;
+
+namespace SmartEstate.Application.Features.Buyers.Queries.GetBuyer;
+
+public record GetBuyerQuery(Guid Id) : IRequest<ErrorOr<BuyerDto>>;

--- a/src/SmartEstate.Application/Features/Buyers/Queries/GetBuyer/GetBuyerQueryHandler.cs
+++ b/src/SmartEstate.Application/Features/Buyers/Queries/GetBuyer/GetBuyerQueryHandler.cs
@@ -1,0 +1,38 @@
+using ErrorOr;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using SmartEstate.Application.Common.Interfaces;
+using SmartEstate.Application.Features.Buyers.DTOs;
+
+namespace SmartEstate.Application.Features.Buyers.Queries.GetBuyer;
+
+public class GetBuyerQueryHandler(IApplicationDbContext db)
+    : IRequestHandler<GetBuyerQuery, ErrorOr<BuyerDto>>
+{
+    public async Task<ErrorOr<BuyerDto>> Handle(GetBuyerQuery request, CancellationToken cancellationToken)
+    {
+        var buyer = await db.Buyers
+            .AsNoTracking()
+            .Where(b => b.Id == request.Id)
+            .Select(b => new BuyerDto
+            {
+                Id = b.Id,
+                AssignedAgentId = b.AssignedAgentId,
+                FullName = b.FullName,
+                Email = b.Email,
+                Phone = b.Phone,
+                LifestyleDescription = b.LifestyleDescription,
+                BudgetMinEur = b.BudgetMinEur,
+                BudgetMaxEur = b.BudgetMaxEur,
+                PreferredLocations = b.PreferredLocations,
+                CreatedAt = b.CreatedAt,
+                UpdatedAt = b.UpdatedAt
+            })
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (buyer is null)
+            return Error.NotFound(description: "Buyer not found.");
+
+        return buyer;
+    }
+}


### PR DESCRIPTION
## Summary

- `GetBuyerQuery` + handler — 404 if not found, wrong tenant, or soft-deleted (global query filter handles all three)
- `UpdateBuyerCommand` + handler + validator — same validation rules as Create; `UpdatedAt` set automatically by `SaveChangesAsync`
- PUT does not allow changing `TenantId`, `AssignedAgentId`, AI fields, or `IsDeleted`
- `BuyersController` extended with `GET /api/buyers/{id}` and `PUT /api/buyers/{id}`

> **Note:** This PR is stacked on top of #46 (base branch = `feature/46-buyers-create-list`). Merge #46 first, then change base to `main` before merging this one.

Closes #47