### PR TITLE
[Backend] DELETE /api/buyers/{id} soft delete

### DIFF
--- a/src/SmartEstate.API/Controllers/BuyersController.cs
+++ b/src/SmartEstate.API/Controllers/BuyersController.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Mvc;
 using SmartEstate.API.Models.Requests;
 using SmartEstate.Application.Common.Models;
 using SmartEstate.Application.Features.Buyers.Commands.CreateBuyer;
+using SmartEstate.Application.Features.Buyers.Commands.DeleteBuyer;
 using SmartEstate.Application.Features.Buyers.Commands.UpdateBuyer;
 using SmartEstate.Application.Features.Buyers.DTOs;
 using SmartEstate.Application.Features.Buyers.Queries.GetBuyer;
@@ -77,6 +78,15 @@ public class BuyersController(ISender mediator) : ControllerBase
         var result = await mediator.Send(command, ct);
         return result.Match(
             dto => Ok(ApiResponse<BuyerDto>.Ok(dto)),
+            errors => MapErrors(errors));
+    }
+
+    [HttpDelete("{id:guid}")]
+    public async Task<IActionResult> Delete(Guid id, CancellationToken ct)
+    {
+        var result = await mediator.Send(new DeleteBuyerCommand(id), ct);
+        return result.Match(
+            _ => Ok(ApiResponse.Ok("Buyer deleted.")),
             errors => MapErrors(errors));
     }
 

--- a/src/SmartEstate.Application/Features/Buyers/Commands/DeleteBuyer/DeleteBuyerCommand.cs
+++ b/src/SmartEstate.Application/Features/Buyers/Commands/DeleteBuyer/DeleteBuyerCommand.cs
@@ -1,0 +1,6 @@
+using ErrorOr;
+using MediatR;
+
+namespace SmartEstate.Application.Features.Buyers.Commands.DeleteBuyer;
+
+public record DeleteBuyerCommand(Guid Id) : IRequest<ErrorOr<Deleted>>;

--- a/src/SmartEstate.Application/Features/Buyers/Commands/DeleteBuyer/DeleteBuyerCommandHandler.cs
+++ b/src/SmartEstate.Application/Features/Buyers/Commands/DeleteBuyer/DeleteBuyerCommandHandler.cs
@@ -1,0 +1,25 @@
+using ErrorOr;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using SmartEstate.Application.Common.Interfaces;
+
+namespace SmartEstate.Application.Features.Buyers.Commands.DeleteBuyer;
+
+public class DeleteBuyerCommandHandler(IApplicationDbContext db)
+    : IRequestHandler<DeleteBuyerCommand, ErrorOr<Deleted>>
+{
+    public async Task<ErrorOr<Deleted>> Handle(DeleteBuyerCommand request, CancellationToken cancellationToken)
+    {
+        var buyer = await db.Buyers
+            .Where(b => b.Id == request.Id)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (buyer is null)
+            return Error.NotFound(description: "Buyer not found.");
+
+        buyer.IsDeleted = true;
+        await db.SaveChangesAsync(cancellationToken);
+
+        return Result.Deleted;
+    }
+}


### PR DESCRIPTION
## Summary

- `DeleteBuyerCommand` + handler — soft delete (`IsDeleted = true`), `UpdatedAt` set via `SaveChangesAsync`
- Returns 404 if buyer not found or already deleted (global query filter excludes `IsDeleted = true`)
- Returns `200 Ok(ApiResponse.Ok("Buyer deleted."))` — no 204
- `MatchReport` records preserved (Sprint 5 dependency)
- `BuyersController` extended with `DELETE /api/buyers/{id}`

> **Note:** This PR is stacked on #47 (base = `feature/47-buyers-get-update`). Merge order: #46 → #47 → #48, changing base to `main` before each merge.

Closes #48