### PR TITLE
[Frontend] Buyer models, BuyerService, and navigation entry (#49)

### DIFF
--- a/src/SmartEstate.Web/Models/Buyers/BuyerDto.cs
+++ b/src/SmartEstate.Web/Models/Buyers/BuyerDto.cs
@@ -1,0 +1,16 @@
+namespace SmartEstate.Web.Models.Buyers;
+
+public class BuyerDto
+{
+    public Guid Id { get; init; }
+    public string FullName { get; init; } = string.Empty;
+    public string? Email { get; init; }
+    public string? Phone { get; init; }
+    public string LifestyleDescription { get; init; } = string.Empty;
+    public decimal? BudgetMinEur { get; init; }
+    public decimal? BudgetMaxEur { get; init; }
+    public List<string> PreferredLocations { get; init; } = [];
+    public Guid AssignedAgentId { get; init; }
+    public DateTime CreatedAt { get; init; }
+    public DateTime? UpdatedAt { get; init; }
+}

--- a/src/SmartEstate.Web/Models/Buyers/BuyerListItemDto.cs
+++ b/src/SmartEstate.Web/Models/Buyers/BuyerListItemDto.cs
@@ -1,0 +1,13 @@
+namespace SmartEstate.Web.Models.Buyers;
+
+public class BuyerListItemDto
+{
+    public Guid Id { get; init; }
+    public string FullName { get; init; } = string.Empty;
+    public string? Email { get; init; }
+    public string? Phone { get; init; }
+    public decimal? BudgetMinEur { get; init; }
+    public decimal? BudgetMaxEur { get; init; }
+    public List<string> PreferredLocations { get; init; } = [];
+    public DateTime CreatedAt { get; init; }
+}

--- a/src/SmartEstate.Web/Models/Buyers/CreateBuyerRequest.cs
+++ b/src/SmartEstate.Web/Models/Buyers/CreateBuyerRequest.cs
@@ -1,0 +1,12 @@
+namespace SmartEstate.Web.Models.Buyers;
+
+public class CreateBuyerRequest
+{
+    public string FullName { get; set; } = string.Empty;
+    public string? Email { get; set; }
+    public string? Phone { get; set; }
+    public string LifestyleDescription { get; set; } = string.Empty;
+    public decimal? BudgetMinEur { get; set; }
+    public decimal? BudgetMaxEur { get; set; }
+    public List<string> PreferredLocations { get; set; } = [];
+}

--- a/src/SmartEstate.Web/Models/Buyers/UpdateBuyerRequest.cs
+++ b/src/SmartEstate.Web/Models/Buyers/UpdateBuyerRequest.cs
@@ -1,0 +1,12 @@
+namespace SmartEstate.Web.Models.Buyers;
+
+public class UpdateBuyerRequest
+{
+    public string FullName { get; set; } = string.Empty;
+    public string? Email { get; set; }
+    public string? Phone { get; set; }
+    public string LifestyleDescription { get; set; } = string.Empty;
+    public decimal? BudgetMinEur { get; set; }
+    public decimal? BudgetMaxEur { get; set; }
+    public List<string> PreferredLocations { get; set; } = [];
+}

--- a/src/SmartEstate.Web/Models/Common/PagedResult.cs
+++ b/src/SmartEstate.Web/Models/Common/PagedResult.cs
@@ -1,0 +1,12 @@
+namespace SmartEstate.Web.Models.Common;
+
+public class PagedResult<T>
+{
+    public List<T> Items { get; init; } = [];
+    public int TotalCount { get; init; }
+    public int PageNumber { get; init; }
+    public int PageSize { get; init; }
+    public int TotalPages => (int)Math.Ceiling((double)TotalCount / PageSize);
+    public bool HasPreviousPage => PageNumber > 1;
+    public bool HasNextPage => PageNumber < TotalPages;
+}

--- a/src/SmartEstate.Web/Program.cs
+++ b/src/SmartEstate.Web/Program.cs
@@ -27,5 +27,6 @@ builder.Services.AddScoped<AuthenticationStateProvider>(
 builder.Services.AddScoped<ApiClient>();
 builder.Services.AddScoped<AuthService>();
 builder.Services.AddScoped<TenantAdminService>();
+builder.Services.AddScoped<BuyerService>();
 
 await builder.Build().RunAsync();

--- a/src/SmartEstate.Web/Services/ApiClient.cs
+++ b/src/SmartEstate.Web/Services/ApiClient.cs
@@ -17,6 +17,9 @@ public class ApiClient(HttpClient http, ILocalStorageService localStorage, Navig
     public Task<ApiResponse<T>?> PostAsync<T>(string url, object body) =>
         SendAsync<T>(HttpMethod.Post, url, body);
 
+    public Task<ApiResponse<T>?> PutAsync<T>(string url, object body) =>
+        SendAsync<T>(HttpMethod.Put, url, body);
+
     public Task<ApiResponse<T>?> PatchAsync<T>(string url, object body) =>
         SendAsync<T>(HttpMethod.Patch, url, body);
 

--- a/src/SmartEstate.Web/Services/BuyerService.cs
+++ b/src/SmartEstate.Web/Services/BuyerService.cs
@@ -1,0 +1,50 @@
+using SmartEstate.Web.Models.Buyers;
+using SmartEstate.Web.Models.Common;
+
+namespace SmartEstate.Web.Services;
+
+public class BuyerService(ApiClient api)
+{
+    public async Task<PagedResult<BuyerListItemDto>?> GetListAsync(int pageNumber, int pageSize, string? search = null)
+    {
+        var url = $"api/buyers?pageNumber={pageNumber}&pageSize={pageSize}";
+        if (!string.IsNullOrWhiteSpace(search))
+            url += $"&search={Uri.EscapeDataString(search)}";
+
+        var response = await api.GetAsync<PagedResult<BuyerListItemDto>>(url);
+        return response?.Success == true ? response.Data : null;
+    }
+
+    public async Task<BuyerDto?> GetByIdAsync(Guid id)
+    {
+        var response = await api.GetAsync<BuyerDto>($"api/buyers/{id}");
+        return response?.Success == true ? response.Data : null;
+    }
+
+    public async Task<(BuyerDto? buyer, string? error)> CreateAsync(CreateBuyerRequest request)
+    {
+        var response = await api.PostAsync<BuyerDto>("api/buyers", request);
+        if (response?.Success == true && response.Data is not null)
+            return (response.Data, null);
+
+        return (null, response?.Message ?? "Failed to create buyer.");
+    }
+
+    public async Task<(BuyerDto? buyer, string? error)> UpdateAsync(Guid id, UpdateBuyerRequest request)
+    {
+        var response = await api.PutAsync<BuyerDto>($"api/buyers/{id}", request);
+        if (response?.Success == true && response.Data is not null)
+            return (response.Data, null);
+
+        return (null, response?.Message ?? "Failed to update buyer.");
+    }
+
+    public async Task<(bool success, string? error)> DeleteAsync(Guid id)
+    {
+        var response = await api.DeleteAsync<object>($"api/buyers/{id}");
+        if (response?.Success == true)
+            return (true, null);
+
+        return (false, response?.Message ?? "Failed to delete buyer.");
+    }
+}

--- a/src/SmartEstate.Web/_Imports.razor
+++ b/src/SmartEstate.Web/_Imports.razor
@@ -16,4 +16,6 @@
 @using SmartEstate.Web.Services
 @using SmartEstate.Web.Models.Auth
 @using SmartEstate.Web.Models.Common
+@using SmartEstate.Web.Models.Buyers
+@using SmartEstate.Web.Models.Admin
 @using System.ComponentModel.DataAnnotations


### PR DESCRIPTION
## Summary
- Added `BuyerDto`, `BuyerListItemDto`, `CreateBuyerRequest`, `UpdateBuyerRequest` in `Web/Models/Buyers/`
- Added `PagedResult<T>` in `Web/Models/Common/`
- Implemented `BuyerService` wrapping all 5 buyer API endpoints
- Added `PutAsync<T>` to `ApiClient`
- Registered `BuyerService` in `Program.cs`
- Added `@using SmartEstate.Web.Models.Buyers` and `@using SmartEstate.Web.Models.Admin` to `_Imports.razor`
- Navigation entry for `/buyers` was already present in `NavMenu.razor`

## Test plan
- [ ] Project builds without errors
- [ ] `BuyerService` is resolvable via DI
- [ ] `ApiClient.PutAsync` is callable

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)